### PR TITLE
link to plugin directory in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # Welcome to Flow Launcher's plugins repository
 
-This repository contains the information for community-made plugins used in [Flow](https://github.com/Flow-Launcher/Flow.Launcher) and how to make submissions.
+This repository contains the information for community-made plugins used in [Flow](https://github.com/Flow-Launcher/Flow.Launcher) and how to make new submissions.
 
 [![AutoUpdate](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml/badge.svg?branch=main)](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml)
+
+## List of Flow plugins
+
+Looking for a list of currently available plugins in Flow? Visit [here](https://flow-launcher.github.io/docs/#/plugins) 
 
 ## How to submit your plugin
 


### PR DESCRIPTION
add link to the current list of available plugins in flow docs, which is generated from the plugins.json here 