### PR TITLE
create new branch for plugin api v2

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -27,5 +27,5 @@ jobs:
         with:
           commit_message: "auto updated plugins"
           push_options: --force
-          branch: plugin_api_v2
+          branch: main
         

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -27,5 +27,5 @@ jobs:
         with:
           commit_message: "auto updated plugins"
           push_options: --force
-          branch: main
+          branch: plugin_api_v2
         

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the information for community-made plugins used in [Flow](https://github.com/Flow-Launcher/Flow.Launcher) and how to make new submissions.
 
-[![AutoUpdate](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml/badge.svg?branch=main)](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml)
+[![AutoUpdate](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml/badge.svg?branch=plugin_api_v2)](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml)
 
 ## List of Flow plugins
 


### PR DESCRIPTION
new branch for api v2, will also be set as default and used from flow version 1.8.0 and onwards. From discussion https://github.com/Flow-Launcher/Flow.Launcher/discussions/535#discussioncomment-961148