### PR TITLE
CLN: remove duplicate checking

### DIFF
--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -8,16 +8,11 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7, 3.8]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.x"
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
why there have the same two checks(py3.7, py3.8)?

I consider this has from a test view.
In other projects, I have to handle very thin different version style changes.

Back to this, this project doesn't need to think more about that.
From the function to check pr is fine.