### PR TITLE
CI: check running when plugins.json get changed

### DIFF
--- a/.github/workflows/validator.yaml
+++ b/.github/workflows/validator.yaml
@@ -1,9 +1,12 @@
 name: Plugins manifest validation
 
-
-# Triggers the workflow on push or pull request events
-on: [push, pull_request]
-
+on:
+  push:
+    paths:
+      - "plugins.json"
+  pull_request:
+    paths:
+      - "plugins.json"
 
 jobs:
   test:


### PR DESCRIPTION
[validator](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/blob/main/tests.py) is running only for [plugins.json](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/blob/main/plugins.json).

But we do other things, this ci would also run. That's unnecessary.