### PR TITLE
fix General Converter mismatched ID

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -270,7 +270,7 @@
         "UrlSourceCode": "https://github.com/Zeroto521/Flow.Launcher.Plugin.Timestamp"
     },
     {
-        "ID": "73F2C04D176A45869FF569FAE63321EF",
+        "ID": "73f2c04d-176a-4586-9ff5-69fae63321ef",
         "Name": "General Converter",
         "Description": "General weights and measures converter",
         "Author": "deefrawley",


### PR DESCRIPTION
General Converter's submitted ID is not the same as what's in the repo. This fixes it up.

Need to also add validation to check against this. https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/issues/47