### PR TITLE
update Flow.Launcher.Plugin.Favorites v1.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -398,7 +398,7 @@
         "Version": "1.2",
         "Language": "csharp",
         "Website": "https://github.com/stax76/Flow.Launcher.Plugin.Favorites",
-        "UrlDownload": "https://github.com/stax76/Flow.Launcher.Plugin.Favorites/releases/download/v1.2/Flow.Launcher.Plugin.Favorites-v1.2.zip",
+        "UrlDownload": "https://github.com/stax76/Flow.Launcher.Plugin.Favorites/releases/download/v1.3/Flow.Launcher.Plugin.Favorites-v1.3.zip",
         "UrlSourceCode": "https://github.com/stax76/Flow.Launcher.Plugin.Favorites/tree/master",
         "IcoPath": "https://raw.githubusercontent.com/stax76/Flow.Launcher.Plugin.Favorites/master/Icons/Web.ico",
         "ETag": "W/\"deceda721020893e3f41c99faf98ed0b427448195cc6f8622bbdc207be36958b\""


### PR DESCRIPTION
Flow.Launcher.Plugin.Favorites v1.3 supports portable mode.