### PR TITLE
Python Plugin Testing upgrade

### DIFF
--- a/ci/envs/requirements-test-python.txt
+++ b/ci/envs/requirements-test-python.txt
@@ -1,1 +1,2 @@
 requests==2.25.1
+pyyaml==6.0

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -63,7 +63,7 @@ def get_latest_plugin(manifest: dict) -> dict:
                 sys.exit(0)
             break
     else:
-        print("No Untested plugin found!")
+        print_section("Test failed!", "No Untested plugin found!\nTest could not find a plugin without \"Tested\" key.")
         sys.exit(1)
     return _plugin
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -81,7 +81,7 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
     args = json.dumps(
         {"method": "query", "parameters": [""], "Settings": default_settings}
     )
-    full_args = ["python", "-S", Path(Path(plugin_path, execute_path)), args]
+    full_args = ["python", "-S", Path(plugin_path, execute_path), args]
     # Older Flox used environmental variable to locate Images directory
     os.environ["PYTHONPATH"] = str(USER_PATH.joinpath("PythonEmbeddable"))
     print_section("Input", full_args)

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -16,15 +16,18 @@ APP_PATH = Path(os.environ["LOCALAPPDATA"], "FlowLauncher")
 USER_DIRS = ["Settings", "Logs", "PythonEmbeddable", "Themes", "Plugins"]
 APP_DIRS = ["Images"]
 
-def _mkdir(path):
+def _mkdir(path: str) -> None:
+    """Create directory if it doesn't exist."""
     if not os.path.exists(path):
         os.mkdir(path)
 
 def print_section(title: str, text: str, char: str = "#", repeat_times: int = 20) -> None:
+    """Print a section with a title and text."""
     _title_line = f'{char * repeat_times} {title} {char * repeat_times}'
     print(_title_line, text, sep="\n")
 
-def get_github_release(url):
+def get_github_release(url: str) -> str:
+    """Get latest release from GitHub."""
     _url = url.split("/")
     author = _url[3]
     plugin_name = _url[4]
@@ -46,16 +49,19 @@ def install(plugin: dict) -> str:
     file.extractall(extract_dir)
     return extract_dir
 
-def _download(url):
+def _download(url: str) -> zipfile.ZipFile:
+    """Download plugin from url."""
     r = requests.get(url)
     r.raise_for_status()
     return zipfile.ZipFile(io.BytesIO(r.content))
 
-def read_plugin(file_path):
+def read_plugin(file_path: str) -> dict:
+    """Read plugin's manifest."""
     with open(file_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
 def get_latest_plugin(manifest: dict) -> dict:
+    """Get latest plugin from manifest."""
     untested_plugins = []
     for _plugin in manifest[::-1]:
         if _plugin["Language"] == "python" and "Tested" not in _plugin.keys():

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -146,10 +146,8 @@ if __name__ == "__main__":
 
     # Get latest untested plugin
     plugin = get_latest_plugin(manifest)
-    name = plugin["Name"]
-    id = plugin["ID"]
-    version = plugin["Version"]
-    print(f"Found untested plugin: {name}")
+    name, id, version = plugin["Name"], plugin["ID"], plugin["Version"]
+    print(f"Found untested plugin: {name} (Version: {version})")
 
     # Set up the Flow environment
     print("Setting up Flow Launcher environment...")
@@ -170,7 +168,7 @@ if __name__ == "__main__":
 
     # Run plugin
     print("Running plugin...")
-    run_plugin(plugin['Name'], plugin_path, execute_file)
+    run_plugin(name, plugin_path, execute_file)
 
 
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -54,7 +54,9 @@ def run_plugin(plugin_name, plugin_path, execute_path):
     args = json.dumps(
         {"method": "query", "parameters": [""], "Settings": default_settings}
     )
-    p = Popen(["python", "-S", Path(Path(plugin_path, execute_path)), args], text=True, stdout=PIPE, stderr=PIPE)
+    full_args = ["python", "-S", Path(Path(plugin_path, execute_path)), args]
+    print(f'{"#" * 9} Input {"#" * 9}\n{full_args}')
+    p = Popen(full_args, text=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     exit_code = p.wait()
     if stdout != "":

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -1,4 +1,5 @@
 import sys
+from time import time
 import json
 import os
 from pathlib import Path
@@ -160,6 +161,7 @@ def test_valid_json(data: dict) -> None:
         return True, e
 
 if __name__ == "__main__":
+    start = time()
     # Load plugins manifest
     manifest = plugin_reader()
 
@@ -188,6 +190,7 @@ if __name__ == "__main__":
     # Run plugin
     print("Running plugin...")
     run_plugin(name, plugin_path, execute_file)
+    print(f'Test finished in {time() - start:.2f} seconds.')
 
 
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -16,6 +16,10 @@ APP_PATH = Path(os.environ["LOCALAPPDATA"], "FlowLauncher")
 USER_DIRS = ["Settings", "Logs", "PythonEmbeddable", "Themes", "Plugins"]
 APP_DIRS = ["Images"]
 
+def _mkdir(path):
+    if not os.path.exists(path):
+        os.mkdir(path)
+
 def get_download_url(url):
     _url = url.split("/")
     author = _url[3]
@@ -64,14 +68,14 @@ def run_plugin(plugin_path, execute_path):
         sys.exit(exit_code)
 
 def setup_flow_environment():
-    os.mkdir(USER_PATH)
-    os.mkdir(APP_PATH)
+    _mkdir(USER_PATH)
+    _mkdir(APP_PATH)
     for _dir in USER_DIRS:
-        os.mkdir(Path(USER_PATH, _dir))
+        _mkdir(Path(USER_PATH, _dir))
     for _dir in APP_DIRS:
-        os.mkdir(Path(APP_PATH, _dir))
-    os.makedirs(Path(USER_PATH, "Settings", "Plugins"))
-    os.makedirs(Path(APP_PATH, "app-1.9.0"))
+        _mkdir(Path(APP_PATH, _dir))
+    os.makedirs(Path(USER_PATH, "Settings", "Plugins"), exist_ok=True)
+    os.makedirs(Path(APP_PATH, "app-1.9.0"), exist_ok=True)
     with open(USER_PATH.joinpath("Settings", "Settings.json"), "w") as f:
         json.dump({
             "PluginSettings": {"Plugins": {}},
@@ -88,7 +92,7 @@ def init_settings(plugin_name, plugin_path):
                 if "defaultValue" in ui_element['attributes'].keys():
                     default_values[ui_element['attributes']['name']] = ui_element['attributes']['defaultValue']
         settings_path = Path(USER_PATH, "Settings", "Plugins", plugin_name)
-        os.mkdir(settings_path)
+        _mkdir(settings_path)
         with open(settings_path.joinpath("Settings.json"), "w") as f:
             f.write(json.dumps(default_values, indent=4))             
     return json.dumps(default_values)
@@ -126,7 +130,7 @@ if __name__ == "__main__":
     z = download_release(latest_release)
     zip_dir = USER_PATH.joinpath("Plugins", plugin['Name'])
     try:
-        os.mkdir(zip_dir)
+        _mkdir(zip_dir)
     except FileExistsError:
         pass
     print("Extracting...")

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -20,10 +20,9 @@ def _mkdir(path):
     if not os.path.exists(path):
         os.mkdir(path)
 
-def print_section(title: str, text: str, char: str = "#", repeat_times: int = 9) -> str:
-    _section_string = f'{char * repeat_times} {title} {char * repeat_times}\n{text}'
-    print(_section_string)
-    return _section_string
+def print_section(title: str, text: str, char: str = "#", repeat_times: int = 20) -> None:
+    _title_line = f'{char * repeat_times} {title} {char * repeat_times}'
+    print(_title_line, text, sep="\n")
 
 def get_github_release(url):
     _url = url.split("/")
@@ -86,7 +85,7 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
         print_section("Output", stdout)
         valid_json = test_valid_json(stdout)
     if exit_code == 0 and valid_json:
-        print_section("Test passed!", "")
+        print_section("Test passed!", "", repeat_times=20)
     else:
         print(f'Test failed!\nPlugin returned a non-zero exit code!')
         if stderr != "":

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -33,8 +33,8 @@ def get_github_release(url):
     print(f'Downloading from {download_url}')
     return download_url
 
-def download_and_extract(plugin: dict) -> str:
-    """Download and extract plugin."""
+def install(plugin: dict) -> str:
+    """Download and install plugin."""
     if "UrlDownload" in plugin.keys():
         print(f'Downloading from {plugin["UrlDownload"]}')
         file = _download(plugin["UrlDownload"])
@@ -163,7 +163,7 @@ if __name__ == "__main__":
     setup_flow_environment()
 
     # Download latest release
-    extract_dir = download_and_extract(plugin)
+    extract_dir = install(plugin)
 
     # Locate Plugins manifest file (plugins.json)
     for path in Path(extract_dir).glob("**/plugin.json"):

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -51,7 +51,7 @@ def read_plugin(file_path):
     with open(file_path, "r", encoding="utf-8") as f:
         return json.load(f)
 
-def get_latest_plugin(manifest):
+def get_latest_plugin(manifest: dict) -> dict:
     for _plugin in manifest[::-1]:
         if _plugin["Language"] == "python" and "Tested" not in _plugin.keys():
             if "github.com" not in _plugin["UrlSourceCode"]:
@@ -63,7 +63,8 @@ def get_latest_plugin(manifest):
         sys.exit(1)
     return _plugin
 
-def run_plugin(plugin_name, plugin_path, execute_path):
+def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
+    """Run plugin and check output."""
     os.chdir(plugin_path)
     default_settings = init_settings(plugin_name, plugin_path)
     args = json.dumps(
@@ -103,7 +104,7 @@ def setup_flow_environment():
         }, f, indent=4)
     
 def init_settings(plugin_name: str, plugin_path: str) -> dict:
-    """Add settings for the plugin to Flow Launcher's settings file."""
+    """Read plugins template file and initialize settings."""
     default_values = {}
     path = Path(plugin_path, "SettingsTemplate.yaml")
     if path.exists():
@@ -119,7 +120,8 @@ def init_settings(plugin_name: str, plugin_path: str) -> dict:
             f.write(json.dumps(default_values, indent=4))             
     return json.dumps(default_values)
 
-def create_plugin_settings(id, name, version, action_keyword):
+def create_plugin_settings(id, name, version, action_keyword) -> None:
+    """Add settings for the plugin to Flow Launcher's settings file."""
     with open(USER_PATH.joinpath("Settings", "Settings.json"), "r") as f:
         settings = json.load(f)
     settings['PluginSettings']['Plugins'][id] = {
@@ -133,7 +135,8 @@ def create_plugin_settings(id, name, version, action_keyword):
     with open(USER_PATH.joinpath("Settings", "Settings.json"), "w") as f:
         json.dump(settings, f, indent=4)
 
-def test_valid_json(data):
+def test_valid_json(data: dict) -> None:
+    """Test if the data is valid JSON."""
     try:
         json.loads(data)
     except Exception as e:

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -56,16 +56,16 @@ def read_plugin(file_path):
         return json.load(f)
 
 def get_latest_plugin(manifest: dict) -> dict:
+    untested_plugins = []
     for _plugin in manifest[::-1]:
         if _plugin["Language"] == "python" and "Tested" not in _plugin.keys():
-            if "github.com" not in _plugin["UrlSourceCode"]:
-                print("Non-Github based website!")
-                sys.exit(0)
-            break
-    else:
+            untested_plugins.append(_plugin)
+    if len(untested_plugins) == 0:
         print_section("Test failed!", "No Untested plugin found!\nTest could not find a plugin without \"Tested\" key.")
         sys.exit(1)
-    return _plugin
+    if len(untested_plugins) > 1:
+        print("Warning: More than one untested plugin found!\nTest will use the first untested plugin.")
+    return untested_plugins[0]
 
 def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
     """Run plugin and check output."""

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -83,13 +83,15 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
     exit_code = p.wait()
     if stdout != "":
         print_section("Output", stdout)
-        valid_json = test_valid_json(stdout)
+        valid_json, json_msg = test_valid_json(stdout)
     if exit_code == 0 and valid_json:
         print_section("Test passed!", "", repeat_times=20)
     else:
         print(f'Test failed!\nPlugin returned a non-zero exit code!')
         if stderr != "":
             print_section('Trace', stderr)
+        if json_msg:
+            print(json_msg)
         sys.exit(exit_code)
 
 
@@ -142,13 +144,13 @@ def create_plugin_settings(id, name, version, action_keyword) -> None:
 
 def test_valid_json(data: dict) -> None:
     """Test if the data is valid JSON."""
+    e = None
     try:
         json.loads(data)
     except Exception as e:
-        print(f'Invalid JSON!\n{e}')
-        return False
+        return False, e
     else:
-        return True
+        return True, e
 
 if __name__ == "__main__":
     # Load plugins manifest

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -70,6 +70,8 @@ def run_plugin(plugin_name, plugin_path, execute_path):
         {"method": "query", "parameters": [""], "Settings": default_settings}
     )
     full_args = ["python", "-S", Path(Path(plugin_path, execute_path)), args]
+    # Older Flox used environmental variable to locate Images directory
+    os.environ["PYTHONPATH"] = str(USER_PATH.joinpath("PythonEmbeddable"))
     print(f'{"#" * 9} Input {"#" * 9}\n{full_args}')
     p = Popen(full_args, text=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -99,7 +99,7 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
             print_section('Trace', stderr)
         if json_msg:
             print(json_msg)
-        sys.exit(exit_code)
+        sys.exit(max(exit_code, 1))
 
 
 def setup_flow_environment() -> None:

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -20,6 +20,11 @@ def _mkdir(path):
     if not os.path.exists(path):
         os.mkdir(path)
 
+def print_section(title: str, text: str, char: str = "#", repeat_times: int = 9) -> str:
+    _section_string = f'{char * repeat_times} {title} {char * repeat_times}\n{text}'
+    print(_section_string)
+    return _section_string
+
 def get_github_release(url):
     _url = url.split("/")
     author = _url[3]
@@ -73,19 +78,19 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
     full_args = ["python", "-S", Path(Path(plugin_path, execute_path)), args]
     # Older Flox used environmental variable to locate Images directory
     os.environ["PYTHONPATH"] = str(USER_PATH.joinpath("PythonEmbeddable"))
-    print(f'{"#" * 9} Input {"#" * 9}\n{full_args}')
+    print_section("Input", full_args)
     p = Popen(full_args, text=True, stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     exit_code = p.wait()
     if stdout != "":
-        print(f'{"#" * 9} Output {"#" * 9}\n{stdout}')
+        print_section("Output", stdout)
         valid_json = test_valid_json(stdout)
     if exit_code == 0 and valid_json:
-        print("Test passed!")
+        print_section("Test passed!", "")
     else:
-        print(f'Test failed!\nPlugin returned a non-zero exit code!\n{"#" * 9} Trace {"#" * 9}')
+        print(f'Test failed!\nPlugin returned a non-zero exit code!')
         if stderr != "":
-            print(stderr)
+            print_section('Trace', stderr)
         sys.exit(exit_code)
 
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -93,7 +93,8 @@ def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:
         sys.exit(exit_code)
 
 
-def setup_flow_environment():
+def setup_flow_environment() -> None:
+    """Setup Flow Launcher local & roaming directory."""
     _mkdir(USER_PATH)
     _mkdir(APP_PATH)
     for _dir in USER_DIRS:

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -112,7 +112,7 @@ def setup_flow_environment() -> None:
     for _dir in APP_DIRS:
         _mkdir(Path(APP_PATH, _dir))
     os.makedirs(Path(USER_PATH, "Settings", "Plugins"), exist_ok=True)
-    os.makedirs(Path(APP_PATH, "app-1.9.0"), exist_ok=True)
+    os.makedirs(Path(APP_PATH, "app-1.0.0"), exist_ok=True)
     with open(USER_PATH.joinpath("Settings", "Settings.json"), "w") as f:
         json.dump({
             "PluginSettings": {"Plugins": {}},

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -70,7 +70,7 @@ def get_latest_plugin(manifest: dict) -> dict:
         print_section("Test failed!", "No Untested plugin found!\nTest could not find a plugin without \"Tested\" key.")
         sys.exit(1)
     if len(untested_plugins) > 1:
-        print_section("Test failed!, More than one untested plugin found!")
+        print_section("Test failed!", "More than one untested plugin found!")
         sys.exit(1)
     return untested_plugins[0]
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -48,7 +48,7 @@ def get_latest_plugin(manifest):
         sys.exit(1)
     return _plugin
 
-def run_plugin(plugin_path, execute_path):
+def run_plugin(plugin_name, plugin_path, execute_path):
     os.chdir(plugin_path)
     default_settings = init_settings(plugin_name, plugin_path)
     args = json.dumps(
@@ -142,7 +142,7 @@ if __name__ == "__main__":
     print("Adding plugin to Flow Launcher's settings file...")
     create_plugin_settings(id, plugin['Name'], plugin['Version'], read_plugin(path)['ActionKeyword'])
     print("Running plugin...")
-    run_plugin(plugin_path, execute_file)
+    run_plugin(plugin['Name'], plugin_path, execute_file)
 
 
 

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -64,7 +64,8 @@ def get_latest_plugin(manifest: dict) -> dict:
         print_section("Test failed!", "No Untested plugin found!\nTest could not find a plugin without \"Tested\" key.")
         sys.exit(1)
     if len(untested_plugins) > 1:
-        print("Warning: More than one untested plugin found!\nTest will use the first untested plugin.")
+        print_section("Test failed!, More than one untested plugin found!")
+        sys.exit(1)
     return untested_plugins[0]
 
 def run_plugin(plugin_name: str, plugin_path: str, execute_path: str) -> None:

--- a/plugins.json
+++ b/plugins.json
@@ -114,7 +114,8 @@
         "UrlDownload": "https://github.com/deefrawley/Flow.Launcher.Plugin.Currency/releases/download/v1.2.2/Flow.Launcher.Plugin.Currency.zip",
         "UrlSourceCode": "https://github.com/deefrawley/Flow.Launcher.Plugin.Currency/tree/main",
         "ETag": "W/\"a615864c488d5f724dca59d7972f445ac3948e558ce00805adacd23caddfe07e\"",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/deefrawley/Flow.Launcher.Plugin.Currency@main/assets/favicon.ico"
+        "IcoPath": "https://cdn.jsdelivr.net/gh/deefrawley/Flow.Launcher.Plugin.Currency@main/assets/favicon.ico",
+        "Tested": false
     },
     {
         "ID": "E2D2C23B084D41D1B6F60EC79D62CAH6",
@@ -302,8 +303,7 @@
         "UrlDownload": "https://github.com/Garulf/HA-Commander/releases/download/v2.5.0/HA-Commander.zip",
         "UrlSourceCode": "https://github.com/Garulf/HA-Commander/tree/main",
         "ETag": "W/\"bca6d0e0537de1efdf432143926da5114d38f9eb7bdd8b3e296c84843d0f307c\"",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/HA-Commander@main/icons/home-assistant.png",
-        "Tested": false
+        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/HA-Commander@main/icons/home-assistant.png"
     },
     {
         "ID": "28b1bc8d-06e1-4bda-8311-f36e8d4f9915",

--- a/plugins.json
+++ b/plugins.json
@@ -114,8 +114,7 @@
         "UrlDownload": "https://github.com/deefrawley/Flow.Launcher.Plugin.Currency/releases/download/v1.2.2/Flow.Launcher.Plugin.Currency.zip",
         "UrlSourceCode": "https://github.com/deefrawley/Flow.Launcher.Plugin.Currency/tree/main",
         "ETag": "W/\"a615864c488d5f724dca59d7972f445ac3948e558ce00805adacd23caddfe07e\"",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/deefrawley/Flow.Launcher.Plugin.Currency@main/assets/favicon.ico",
-        "Tested": false
+        "IcoPath": "https://cdn.jsdelivr.net/gh/deefrawley/Flow.Launcher.Plugin.Currency@main/assets/favicon.ico"
     },
     {
         "ID": "E2D2C23B084D41D1B6F60EC79D62CAH6",

--- a/plugins.json
+++ b/plugins.json
@@ -303,7 +303,8 @@
         "UrlDownload": "https://github.com/Garulf/HA-Commander/releases/download/v2.5.0/HA-Commander.zip",
         "UrlSourceCode": "https://github.com/Garulf/HA-Commander/tree/main",
         "ETag": "W/\"bca6d0e0537de1efdf432143926da5114d38f9eb7bdd8b3e296c84843d0f307c\"",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/HA-Commander@main/icons/home-assistant.png"
+        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/HA-Commander@main/icons/home-assistant.png",
+        "Tested": false
     },
     {
         "ID": "28b1bc8d-06e1-4bda-8311-f36e8d4f9915",


### PR DESCRIPTION
* Cleans up code
* Doc strings and type hints
* Verify JSON output
* Check and fail on multiple Plugin submission
* Setup faux Flow Launcher structure
* Prioritize `UrlDownload` field for release testing (Fallback to github release if available)
* Support Flox
* Parse `SettingsTemplate.yaml` and send default values to Plugin