### PR TITLE
Detect and pass on non-Python detection

### DIFF
--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -68,7 +68,7 @@ def get_latest_plugin(manifest: dict) -> dict:
         if _plugin["Language"] == "python" and "Tested" not in _plugin.keys():
             untested_plugins.append(_plugin)
         if _plugin["Language"] != "python" and "Tested" not in _plugin.keys():
-            print_section("Non-Python plugin detected!", f'Detected Plugin: {_plugin["name"]}\nPassing test for now...')
+            print_section("Non-Python plugin detected, test not required.", f'Detected Plugin: {_plugin["name"]}\nPassing test...')
             sys.exit(0)
     if len(untested_plugins) == 0:
         print_section("Test failed!", "Test could not find a plugin without \"Tested\" key.")

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -67,8 +67,11 @@ def get_latest_plugin(manifest: dict) -> dict:
     for _plugin in manifest[::-1]:
         if _plugin["Language"] == "python" and "Tested" not in _plugin.keys():
             untested_plugins.append(_plugin)
+        if _plugin["Language"] != "python" and "Tested" not in _plugin.keys():
+            print_section("Non-Python plugin detected!", f'Detected Plugin: {_plugin["name"]}\nPassing test for now...')
+            sys.exit(0)
     if len(untested_plugins) == 0:
-        print_section("Test failed!", "No Untested plugin found!\nTest could not find a plugin without \"Tested\" key.")
+        print_section("Test failed!", "Test could not find a plugin without \"Tested\" key.")
         sys.exit(1)
     if len(untested_plugins) > 1:
         print_section("Test failed!", "More than one untested plugin found!")

--- a/ci/src/test-python.py
+++ b/ci/src/test-python.py
@@ -71,7 +71,7 @@ def get_latest_plugin(manifest: dict) -> dict:
             print_section("Non-Python plugin detected, test not required.", f'Detected Plugin: {_plugin["name"]}\nPassing test...')
             sys.exit(0)
     if len(untested_plugins) == 0:
-        print_section("Test failed!", "Test could not find a plugin without \"Tested\" key.")
+        print_section("Test failed!", "The new plugin should not have the \"Tested\" key.")
         sys.exit(1)
     if len(untested_plugins) > 1:
         print_section("Test failed!", "More than one untested plugin found!")


### PR DESCRIPTION
This should fix non-Python plugins from causing the test to fail.