### PR TITLE
Re-point TimeStamp's url to fork

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -251,10 +251,10 @@
         "Author": "Zero <Zeroto521>",
         "Version": "1.0.8",
         "Language": "python",
-        "Website": "https://github.com/Zeroto521/Flow.Launcher.Plugin.Timestamp",
+        "Website": "https://github.com/Garulf/Flow.Launcher.Plugin.Timestamp",
         "UrlDownload": "https://github.com/Garulf/Flow.Launcher.Plugin.Timestamp/releases/download/v1.0.8/Flow.Launcher.Plugin.TimeStamp.zip",
-        "UrlSourceCode": "https://github.com/Zeroto521/Flow.Launcher.Plugin.Timestamp",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/Zeroto521/Flow.Launcher.Plugin.Timestamp@master/assets/favicon.ico",
+        "UrlSourceCode": "https://github.com/Garulf/Flow.Launcher.Plugin.Timestamp",
+        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/Flow.Launcher.Plugin.Timestamp@master/assets/favicon.ico",
         "Tested": false
     },
     {


### PR DESCRIPTION
This fixes missing etag issue, which uses UrlSourceCode