### PR TITLE
Add Github notifications plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -571,7 +571,7 @@
         "Name": "Github Notifications",
         "Description": "View your github notifications",
         "Author": "Garulf",
-        "Version": "1.0.1",
+        "Version": "1.0.2",
         "Language": "python",
         "Website": "https://github.com/Garulf/github-notifications",
         "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.1/Github-Notifications.zip",

--- a/plugins.json
+++ b/plugins.json
@@ -565,5 +565,18 @@
         "UrlSourceCode": "https://github.com/paradox00/Flow.Launcher.Plugin.WindowsTerminal",
         "IcoPath": "https://cdn.jsdelivr.net/gh/paradox00/Flow.Launcher.Plugin.WindowsTerminal@main/Images/app.png",
         "Tested": true
-    }
+    },
+    {
+        "ID": "9B66F9CD1BF54CBBADCF1ACB378E33BB",
+        "Name": "Github Notifications",
+        "Description": "View your github notifications",
+        "Author": "Garulf",
+        "Version": "1.0.1",
+        "Language": "python",
+        "Website": "https://github.com/Garulf/github-notifications",
+        "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.1/Github-Notifications.zip",
+        "UrlSourceCode": "https://github.com/Garulf/github-notifications/tree/main",
+        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-notifications@main/icon.png"
+      }
+      
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -571,10 +571,10 @@
         "Name": "Github Notifications",
         "Description": "View your github notifications",
         "Author": "Garulf",
-        "Version": "1.0.3",
+        "Version": "1.0.4",
         "Language": "python",
         "Website": "https://github.com/Garulf/github-notifications",
-        "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.3/Github-Notifications.zip",
+        "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.4/Github-Notifications.zip",
         "UrlSourceCode": "https://github.com/Garulf/github-notifications/tree/main",
         "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-notifications@main/icon.png"
       }

--- a/plugins.json
+++ b/plugins.json
@@ -574,7 +574,7 @@
         "Version": "1.0.3",
         "Language": "python",
         "Website": "https://github.com/Garulf/github-notifications",
-        "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.1/Github-Notifications.zip",
+        "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.3/Github-Notifications.zip",
         "UrlSourceCode": "https://github.com/Garulf/github-notifications/tree/main",
         "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-notifications@main/icon.png"
       }

--- a/plugins.json
+++ b/plugins.json
@@ -571,7 +571,7 @@
         "Name": "Github Notifications",
         "Description": "View your github notifications",
         "Author": "Garulf",
-        "Version": "1.0.2",
+        "Version": "1.0.3",
         "Language": "python",
         "Website": "https://github.com/Garulf/github-notifications",
         "UrlDownload": "https://github.com/Garulf/Github-Notifications/releases/download/v1.0.1/Github-Notifications.zip",


### PR DESCRIPTION
Adds a plugin to view your Github notifications:

![image](https://user-images.githubusercontent.com/535299/149210193-37f86e07-7d6a-4165-b2b7-2e4089765309.png)
