### PR TITLE
Send discord webhook on plugin updates

### DIFF
--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Auto Checking Update
         run: |
-          python ./ci/src/updater.py
+          python ./ci/src/updater.py ${{ secrets.DISCORD_WEBHOOK }}
 
       - name: Commit & Push changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/ci/src/_utils.py
+++ b/ci/src/_utils.py
@@ -55,6 +55,9 @@ def etags_writer(content: ETagsType):
 def clean(string: str, flag="-") -> str:
     return string.lower().replace(flag, "").strip()
 
+def version_tuple(version: str) -> tuple:
+    version = clean(version, "v")
+    return tuple(map(int, (version.split("."))))
 
 def check_url(url: str) -> bool:
     regex = re.compile(

--- a/ci/src/discord.py
+++ b/ci/src/discord.py
@@ -1,0 +1,34 @@
+import requests
+
+def update_hook(webhook_url: str, info: dict) -> None:
+    embed = {
+        "content": None,
+        "embeds": [
+            {
+            "title": "Plugin Updated",
+            "description": f"{info['Name']} plugin has been updated to v{info['Version']}!",
+            "url": info['Website'],
+            "color": None,
+            "fields": [
+                {
+                "name": "Author",
+                "value": info['Author'],
+                "inline": True
+                },
+                {
+                "name": "Language",
+                "value": info['Language'],
+                "inline": True
+                },
+                {
+                "name": "Download",
+                "value": info['UrlDownload']
+                }
+            ],
+            "thumbnail": {
+                "url": info['IcoPath']
+            }
+            }
+        ]
+        }
+    requests.post(webhook_url, json=embed)

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -38,9 +38,8 @@ def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str=None) ->
         tqdm.write(f"Update detected: {info[id_name]} {info[version]}")
         try:
             update_hook(webhook_url, info)
-        except:
-            # We dont want to crash if the webhook is not working
-            pass
+        except Exception as e:
+            tqdm.write(e)
         
     tags[info[id_name]] = res.headers.get(etag, "")
 

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -34,7 +34,7 @@ def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str=None) ->
         info[url_download] = assets[0]["browser_download_url"]
         info[version] = clean(latest_rel["tag_name"], "v")
 
-    if info[version] != clean(latest_rel["tag_name"], "v"):
+    if version_tuple(info[version]) < version_tuple(latest_rel["tag_name"]):
         tqdm.write(f"Update detected: {info[id_name]} {info[version]}")
         try:
             update_hook(webhook_url, info)

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -35,7 +35,7 @@ def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str=None) ->
         info[version] = clean(latest_rel["tag_name"], "v")
     else:
         try:
-            update_hook(webhook, info)
+            update_hook(webhook_url, info)
         except:
             # We dont want to crash if the webhook is not working
             pass

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -33,7 +33,9 @@ def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str=None) ->
     if assets:
         info[url_download] = assets[0]["browser_download_url"]
         info[version] = clean(latest_rel["tag_name"], "v")
-    else:
+
+    if info[version] != clean(latest_rel["tag_name"], "v"):
+        tqdm.write(f"Update detected: {info[id_name]} {info[version]}")
         try:
             update_hook(webhook_url, info)
         except:

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -1,13 +1,16 @@
 # -*-coding: utf-8 -*-
 from http.client import responses
 from typing import List
+from unicodedata import name
+from sys import argv
 
 import requests
 from tqdm import tqdm
 
 from _utils import *
+from discord import update_hook
 
-def batch_github_plugin_info(info: P, tags: ETagsType) -> P:
+def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str=None) -> P:
     if "github.com" not in info[url_download]:
         return info
 
@@ -30,19 +33,28 @@ def batch_github_plugin_info(info: P, tags: ETagsType) -> P:
     if assets:
         info[url_download] = assets[0]["browser_download_url"]
         info[version] = clean(latest_rel["tag_name"], "v")
+    else:
+        try:
+            update_hook(webhook, info)
+        except:
+            # We dont want to crash if the webhook is not working
+            pass
         
     tags[info[id_name]] = res.headers.get(etag, "")
 
     return info
 
 
-def batch_plugin_infos(plugin_infos: Ps, tags: ETagsType) -> Ps:
-    return [batch_github_plugin_info(info, tags) for info in tqdm(plugin_infos)]
+def batch_plugin_infos(plugin_infos: Ps, tags: ETagsType, webhook_url: str=None) -> Ps:
+    return [batch_github_plugin_info(info, tags, webhook_url) for info in tqdm(plugin_infos)]
 
 
 if __name__ == "__main__":
+    webhook_url = None
+    if len(argv) < 1:
+        webhook_url = argv[1]
     plugin_infos = plugin_reader()
     etags = etag_reader()
-    plugin_infos_new = batch_plugin_infos(plugin_infos, etags)
+    plugin_infos_new = batch_plugin_infos(plugin_infos, etags, webhook_url)
     plugin_writer(plugin_infos_new)
     etags_writer(etags)

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -51,7 +51,7 @@ def batch_plugin_infos(plugin_infos: Ps, tags: ETagsType, webhook_url: str=None)
 
 if __name__ == "__main__":
     webhook_url = None
-    if len(argv) < 1:
+    if len(argv) > 1:
         webhook_url = argv[1]
     plugin_infos = plugin_reader()
     etags = etag_reader()


### PR DESCRIPTION
Updater will send a discord webhook to Discord when a plugin's version is changed.

Just need to provide a webhook in repo's secrets named: `DISCORD_WEBHOOK`.

![image](https://user-images.githubusercontent.com/535299/149386090-8f38636b-cf87-49e1-88d1-cd4d50dce2a4.png)
