### PR TITLE
Add Github Quick launcher Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -584,10 +584,10 @@
         "Name": "Github Quick Launcher",
         "Description": "Quickly access your personal repositories and stars.",
         "Author": "Garulf",
-        "Version": "1.0.0",
+        "Version": "1.0.1",
         "Language": "python",
         "Website": "https://github.com/Garulf/github-quick-launcher",
-        "UrlDownload": "https://github.com/Garulf/github-quick-launcher/releases/download/v1.0.0/Github-Quick-Launcher.zip",
+        "UrlDownload": "https://github.com/Garulf/github-quick-launcher/releases/download/v1.0.1/Github-Quick-Launcher.zip",
         "UrlSourceCode": "https://github.com/Garulf/github-quick-launcher/tree/main",
         "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-quick-launcher@main/icon.png"
     }

--- a/plugins.json
+++ b/plugins.json
@@ -578,5 +578,17 @@
         "UrlSourceCode": "https://github.com/Garulf/github-notifications/tree/main",
         "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-notifications@main/icon.png",
         "Tested": true
+    },
+    {
+        "ID": "240B648F33DD4105800747A2749E1B5C",
+        "Name": "Github Quick Launcher",
+        "Description": "Quickly access your personal repositories and stars.",
+        "Author": "Garulf",
+        "Version": "1.0.0",
+        "Language": "python",
+        "Website": "https://github.com/Garulf/github-quick-launcher",
+        "UrlDownload": "https://github.com/Garulf/github-quick-launcher/releases/download/v1.0.0/Github-Quick-Launcher.zip",
+        "UrlSourceCode": "https://github.com/Garulf/github-quick-launcher/tree/main",
+        "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/github-quick-launcher@main/icon.png"
     }
 ]


### PR DESCRIPTION
Simple Github plugin that simplifies accessing repos.

![image](https://user-images.githubusercontent.com/535299/149841131-e444aebc-3a52-4e43-afad-fe792511321c.png)
