### PR TITLE
Add workflowy plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -820,5 +820,17 @@
         "UrlDownload": "https://github.com/LeoDupont/Flow.Launcher.Plugin.DateDiff/releases/download/v1.0.0/Flow.Launcher.Plugin.DateDiff.zip",
         "UrlSourceCode": "https://github.com/LeoDupont/Flow.Launcher.Plugin.DateDiff/tree/main",
         "IcoPath": "https://cdn.jsdelivr.net/gh/LeoDupont/Flow.Launcher.Plugin.DateDiff@main/images/icon.png"
-    }
+    },
+    {
+        "ID": "3b42afc0d17f45b98a55e324728252be",  
+        "Name": "Workflowy",
+        "Description": "Save notes directly into Workflowy",
+        "Author": "BrunoLM",
+        "Version": "1.0.0",
+        "Language": "executable",
+        "Website": "https://github.com/brunolm/workflowy-wf",
+        "UrlDownload":"https://github.com/brunolm/workflowy-wf/releases/download/v1.0.0/Flow.Launcher.Plugin.WorkflowyWF.zip",
+        "UrlSourceCode": "https://github.com/brunolm/workflowy-wf",
+        "IcoPath": "https://cdn.jsdelivr.net/gh/brunolm/workflowy-wf@v1.0.0/icon.jpg"
+      }
 ]


### PR DESCRIPTION
Save notes from anywhere directly into Workflowy.

### Source
https://github.com/brunolm/workflowy-wf

### Video demo
https://www.linkedin.com/posts/brunolm_httpslnkdineee2dstp-flow-launcher-plugin-activity-6924539879074770944-N6qB

### GIF
![](https://cdn.jsdelivr.net/gh/brunolm/workflowy-wf@v1.0.0/README/demo.gif)

### Icon
![](https://cdn.jsdelivr.net/gh/brunolm/workflowy-wf@v1.0.0/icon.jpg)

### Install
![](https://cdn.jsdelivr.net/gh/brunolm/workflowy-wf@v1.0.0/README/installdir.png)