### PR TITLE
Update AWS Toolkit icon path

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -868,6 +868,6 @@
         "Website": "https://github.com/mjtimblin/Flow.Launcher.Plugin.AwsToolkit",
         "UrlDownload": "https://github.com/mjtimblin/Flow.Launcher.Plugin.AwsToolkit/releases/download/v1.0.1/Flow.Launcher.Plugin.AwsToolkit.zip",
         "UrlSourceCode": "https://github.com/mjtimblin/Flow.Launcher.Plugin.AwsToolkit/tree/master",
-        "IcoPath": "https://cdn.jsdelivr.net/gh/mjtimblin/Flow.Launcher.Plugin.AwsToolkit@master/Flow.Launcher.Plugin.AwsToolkit/images/aws.png"
+        "IcoPath": "https://cdn.jsdelivr.net/gh/mjtimblin/Flow.Launcher.Plugin.AwsToolkit@master/icon.png"
     }
 ]


### PR DESCRIPTION
This PR updates the AWS Toolkit plugin's icon path to be consistent with the format many other Flow Launcher plugins use.