### PR TITLE
Add Poi Poi Clipboard Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -984,5 +984,18 @@
         "UrlDownload": "https://github.com/LeLocTai/Flow.Launcher.Plugin.CurrencyPP/releases/download/v3.0.1/Flow.Launcher.Plugin.CurrencyPP.zip",
         "UrlSourceCode": "https://github.com/LeLocTai/Flow.Launcher.Plugin.CurrencyPP",
         "Tested": true
+    },
+    {
+        "ID": "D738C474-9262-4B94-B58D-0413ED8EB9C6",
+        "ActionKeyword": "pp",
+        "Name": "Poi Poi Clipboard",
+        "Description": "Clear clipboard quickly to prevent password leakage",
+        "Author": "PikkamanV",
+        "Version": "1.0.0",
+        "Language": "csharp",
+        "Website": "https://github.com/PikkamanV/Flow.Launcher.Plugin.PoiPoiClipboard",
+        "UrlDownload":"https://github.com/PikkamanV/Flow.Launcher.Plugin.PoiPoiClipboard/releases/download/v1.0.0/PoiPoiClipboard.zip",
+        "UrlSourceCode": "https://github.com/PikkamanV/Flow.Launcher.Plugin.PoiPoiClipboard",
+        "IcoPath": "https://cdn.jsdelivr.net/gh/PikkamanV/Flow.Launcher.Plugin.PoiPoiClipboard@v1.0.0/Flow.Launcher.Plugin.PoiPoiClipboard/Images/icon.png"
     }
 ]


### PR DESCRIPTION
The motivation for creating this plugin is to provide peace of mind by erasing passwords manually copied from the password manager on the clipboard in as few steps as possible.
Improving existing clipboard plugins requires additional arguments and it is cumbersome to type.

More info: https://github.com/PikkamanV/Flow.Launcher.Plugin.PoiPoiClipboard
Note: "Poi" or "poi-suru" means "to throw away" in Japanese. I first tried to name this plugin "Clipboard Eraser" or "Clipboard Cleaner," but apps with the same name already existed.