### PR TITLE
Catch and skip plugins with errors

### DIFF
--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -49,7 +49,7 @@ def batch_github_plugin_info(info: P, tags: ETagsType, webhook_url: str = None) 
         return info
     except Exception as e:
         tb = traceback.format_exc()
-        print(f"Error: {e}\n{tb}")
+        print(f"Error when processing plugin {info[plugin_name]}:\n{e} {tb}")
         return info
 
 


### PR DESCRIPTION
If a plugin causes and error it crashes the entire update script.

With this PR the plugin will be skipped and a traceback will be printed.