### PR TITLE
Add MC Multi Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1225,5 +1225,17 @@
         "Tested": true,
         "DateAdded": "2022-12-12T09:57:51Z",
         "LatestReleaseDate": "2022-12-11T14:22:46Z"
+    },
+    {
+      "ID": "91B97FA34859445782AEF1893DE4E350",
+      "Name": "Minecraft Multi Launcher",
+      "Description": "Launcher your Minecraft instances using MultiMC, PolyMC, and PrismLauncher",
+      "Author": "Garulf",
+      "Version": "1.0.3",
+      "Language": "executable",
+      "Website": "https://github.com/Garulf/mc_multi_launcher",
+      "UrlDownload": "https://github.com/Garulf/MC-Multi-Launcher/releases/download/v1.0.3/Minecraft.Multi.Launcher.zip",
+      "UrlSourceCode": "https://github.com/Garulf/MC-Multi-Launcher",
+      "IcoPath": "https://cdn.jsdelivr.net/gh/garulf/MC-Multi-Launcher@main/src/icon.png"
     }
 ]


### PR DESCRIPTION
Adds a plugin to launch Minecraft instances using MultiMC, PolyMC, and PrismLauncher.

![image](https://user-images.githubusercontent.com/535299/207795159-fa49e942-e527-4871-a054-a10e7ce9085a.png)
