### PR TITLE
Added WhenToExpect

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1540,5 +1540,18 @@
         "UrlSourceCode": "https://github.com/JamesNZL/flow-toggl-plugin",
         "UrlDownload": "https://github.com/JamesNZL/flow-toggl-plugin/releases/download/v1.0.0/Flow.Launcher.Plugin.TogglTrack.zip",
         "DateAdded": "2023-05-12T14:51:58Z"
+    },
+    {
+        "ID": "77435DA907472F189B759F9F4F3E3C23",
+        "ActionKeyword": "when",
+        "Name": "When to Expect",
+        "Description": "Calculates how many tries are needed to expect an event (by default with ≥ 50 % probability).",
+        "Author": "Jonas A. Wendorf",
+        "Version": "1.0.0",
+        "Language": "python",
+        "Website": "https://github.com/jonasw234/FlowLauncher.Plugin.WhenToExpect",
+        "UrlDownload":"https://github.com/jonasw234/FlowLauncher.Plugin.WhenToExpect/releases/download/v1.0.0/Flow.Launcher.Plugin.WhenToExpect.zip",
+        "UrlSourceCode": "https://github.com/jonasw234/FlowLauncher.Plugin.WhenToExpect",
+        "IcoPath": "https://cdn.statically.io/gh/jonasw234/FlowLauncher.Plugin.WhenToExpect/main/icon/expect.png"
     }
 ]


### PR DESCRIPTION
 A plugin for calculating the expected number of trials before an event occurs given a probability (or odds) and confidence level.