### PR TITLE
Remove unused etags

### DIFF
--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -57,6 +57,21 @@ def batch_plugin_infos(plugin_infos: Ps, tags: ETagsType, webhook_url: str = Non
     return [batch_github_plugin_info(info, tags, webhook_url) for info in tqdm(plugin_infos)]
 
 
+def remove_unused_etags(plugin_infos: Ps, etags: ETagsType) -> ETagsType:
+    etags_updated = {}
+    plugin_ids = [info.get("ID") for info in plugin_infos]
+    
+    for id, tag in etags.items():
+        
+        if id not in plugin_ids:
+            print(f"Plugin with ID {id} has been removed. The associated ETag will be also removed now.")
+            continue
+        
+        etags_updated[id] = tag
+    
+    return etags_updated
+
+
 def send_notification(info: P, latest_ver, release, webhook_url: str = None) -> None:
     if version_tuple(info[version]) != version_tuple(latest_ver):
         tqdm.write(f"Update detected: {info[plugin_name]} {latest_ver}")
@@ -72,6 +87,9 @@ if __name__ == "__main__":
         webhook_url = argv[1]
     plugin_infos = plugin_reader()
     etags = etag_reader()
+    
     plugin_infos_new = batch_plugin_infos(plugin_infos, etags, webhook_url)
     plugin_writer(plugin_infos_new)
-    etags_writer(etags)
+    
+    etags_new = remove_unused_etags(plugin_infos_new, etags)
+    etags_writer(etags_new)


### PR DESCRIPTION
Related to #233

During plugin version update, remove any unused ETags after plugins have been removed from the manifest. 