### PR TITLE
remove integer conversion in version tuple

### DIFF
--- a/ci/src/_utils.py
+++ b/ci/src/_utils.py
@@ -63,7 +63,7 @@ def clean(string: str, flag="-") -> str:
 
 def version_tuple(version: str) -> tuple:
     version = clean(version, "v")
-    return tuple(map(int, (version.split("."))))
+    return tuple(version.split("."))
 
 def check_url(url: str) -> bool:
     regex = re.compile(


### PR DESCRIPTION
fix the following bug

```
Error when processing plugin Youtube Downloader:
invalid literal for int() with base 10: '0-beta' Traceback (most recent call last):
  File "/home/runner/work/Flow.Launcher.PluginsManifest/Flow.Launcher.PluginsManifest/./ci/src/updater.py", line 43, in batch_github_plugin_info
    send_notification(info, clean(
  File "/home/runner/work/Flow.Launcher.PluginsManifest/Flow.Launcher.PluginsManifest/./ci/src/updater.py", line 76, in send_notification
    if version_tuple(info[version]) != version_tuple(latest_ver):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/Flow.Launcher.PluginsManifest/Flow.Launcher.PluginsManifest/ci/src/_utils.py", line 66, in version_tuple
    return tuple(map(int, (version.split("."))))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '0-beta'
```