### PR TITLE
Update Steam Search language field

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -380,7 +380,7 @@
         "Description": "Search and launch your Steam Game library",
         "Author": "Garulf",
         "Version": "9.0.1",
-        "Language": "python",
+        "Language": "executable",
         "Website": "https://github.com/Garulf/Steam-Search",
         "UrlDownload": "https://github.com/Garulf/Steam-Search/releases/download/v9.0.1/Steam-Search.zip",
         "UrlSourceCode": "https://github.com/Garulf/Steam-Search/tree/main",


### PR DESCRIPTION
Steam Search is no longer considered a "Python" plugin.