### PR TITLE
Fix 'Update tested plugins' workflow fail

### DIFF
--- a/.github/workflows/python-passed.yml
+++ b/.github/workflows/python-passed.yml
@@ -15,10 +15,10 @@ jobs:
           token: ${{ secrets.UPDATER }}
           # otherwise, you will failed to push refs to dest repo
           fetch-depth: 0
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.x
       - name: Run script
         run: python ./ci/src/update-tested.py
       - name: Update plugin manifest

--- a/plugins/AnyVideo Downloader-70CED0AC-3D9D-4255-AD0B-D9A37862E879.json
+++ b/plugins/AnyVideo Downloader-70CED0AC-3D9D-4255-AD0B-D9A37862E879.json
@@ -9,5 +9,7 @@
     "UrlDownload": "https://github.com/z1nc0r3/AnyVideo-Downloader-Flow-Plugin/releases/download/v1.0.0/Flow.Launcher.Plugin.AnyVideo.Downloader.zip",
     "UrlSourceCode": "https://github.com/z1nc0r3/AnyVideo-Downloader-Flow-Plugin/tree/main",
     "IcoPath": "https://cdn.jsdelivr.net/gh/z1nc0r3/AnyVideo-Downloader-Flow-Plugin@main/Images/app.png",
+    "Tested": true,
+    "DateAdded": "2024-07-30T07:46:00Z",
     "LatestReleaseDate": "2024-07-29T20:43:46Z"
 }

--- a/plugins/Bitwarden-5A8EBCEB7F6940E5B628BE122A87B560.json
+++ b/plugins/Bitwarden-5A8EBCEB7F6940E5B628BE122A87B560.json
@@ -9,5 +9,6 @@
     "UrlDownload": "https://github.com/RedMageKnight/Flow.Launcher.Plugin.BitwardenSearch/releases/download/v1.2.0/Flow.Launcher.Plugin.Bitwarden.zip",
     "UrlSourceCode": "https://github.com/RedMageKnight/Flow.Launcher.Plugin.BitwardenSearch/tree/main",
     "IcoPath": "https://cdn.jsdelivr.net/gh/RedMageKnight/Flow.Launcher.Plugin.BitwardenSearch/Images/bitwarden.png",
+    "DateAdded": "2024-07-22T16:13:00Z",
     "LatestReleaseDate": "2024-07-23T23:44:03Z"
 }

--- a/plugins/Git Easy-AA9EA7B6AB4A4822858BC38FF6344248.json
+++ b/plugins/Git Easy-AA9EA7B6AB4A4822858BC38FF6344248.json
@@ -9,5 +9,6 @@
     "UrlDownload": "https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy/releases/download/v0.3.0/Flow.Launcher.Plugin.GitEasy.zip",
     "UrlSourceCode": "https://github.com/zkwokleung/Flow.Launcher.Plugin.GitEasy",
     "IcoPath": "https://cdn.jsdelivr.net/gh/zkwokleung/Flow.Launcher.Plugin.GitEasy@main/Flow.Launcher.Plugin.GitEasy/Images/icon.png",
+    "DateAdded": "2024-07-19T22:34:00Z",
     "LatestReleaseDate": "2024-07-20T22:45:06Z"
 }

--- a/plugins/ShikiFlow-b34023f6440d11ef94540242ac120002.json
+++ b/plugins/ShikiFlow-b34023f6440d11ef94540242ac120002.json
@@ -9,5 +9,7 @@
     "Website": "https://github.com/NoPlagiarism/ShikiFlow",
     "UrlDownload": "https://github.com/NoPlagiarism/ShikiFlow/releases/download/v1.0.0/Flow.Launcher.Plugin.ShikiFlow.zip",
     "UrlSourceCode": "https://github.com/NoPlagiarism/ShikiFlow/tree/main",
+    "Tested": true,
+    "DateAdded": "2024-08-03T22:34:00Z",
     "LatestReleaseDate": "2024-07-31T18:19:19Z"
 }


### PR DESCRIPTION
Fix 'Update tested plugins' workflow fail due to using unsupported Python version 3.7