### PR TITLE
Update Todos-5B7E53D506844D2D8B7001AA19F5EF8F.json

### DIFF
--- a/plugins/Todos-5B7E53D506844D2D8B7001AA19F5EF8F.json
+++ b/plugins/Todos-5B7E53D506844D2D8B7001AA19F5EF8F.json
@@ -1,14 +1,12 @@
 {
     "ID": "5B7E53D506844D2D8B7001AA19F5EF8F",
     "Name": "Todos",
-    "Description": "A simple todo app.",
-    "Author": "caoyue",
-    "Version": "2.0.1",
+    "Description": "A simple yet effective todo app.",
+    "Author": "Or1g3n (originally by caoyue)",
+    "Version": "3.0.3",
     "Language": "csharp",
-    "Website": "https://github.com/jjw24/Wox.Plugin.Todos",
-    "UrlDownload": "https://github.com/jjw24/Wox.Plugin.Todos/releases/download/v2.0.1/Wox.Plugin.Todos.zip",
-    "UrlSourceCode": "https://github.com/jjw24/Wox.Plugin.Todos/tree/master",
-    "IcoPath": "https://cdn.jsdelivr.net/gh/jjw24/Wox.Plugin.Todos@master/ico/app.png",
-    "LatestReleaseDate": "2021-03-11T09:54:22Z",
-    "DateAdded": "2022-10-08T16:26:57Z"
+    "Website": "https://github.com/Or1g3n/Flow.Launcher.Plugin.Todos",
+    "UrlDownload": "https://github.com/Or1g3n/Flow.Launcher.Plugin.Todos/releases/download/v3.0.3/Flow.Launcher.Plugin.Todos.zip",
+    "UrlSourceCode": "https://github.com/Or1g3n/Flow.Launcher.Plugin.Todos/tree/master",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/Or1g3n/Flow.Launcher.Plugin.Todos@master/ico/app.png"
 }


### PR DESCRIPTION
Pull request to repoint existing todos plugin to new location, https://github.com/Or1g3n/Flow.Launcher.Plugin.Todos. 

Several updates (see url above for summary of changes) were made to the plugin so I reached out to Jeremy Wu to determine best path for incorporating changes. Jeremy suggested I to submit a PR to repoint plugin source to fork so he could then archive the legacy repo.