### PR TITLE
Stable emit of plugins.json, so diffs are more readable

### DIFF
--- a/ci/src/merge-manifest.py
+++ b/ci/src/merge-manifest.py
@@ -2,7 +2,7 @@ import glob
 import json
 
 if __name__ == "__main__":
-    plugins = glob.glob("plugins/*.json")
+    plugins = sorted(glob.glob("plugins/*.json"))
 
     manifests = []
 


### PR DESCRIPTION
Disclaimer: I haven't tested this locally, but the change was so tiny, figured I should propose it as-is.

I noticed that the diffs on plugins.json are unreadable because the ordering of plugins changes every time.

As a plugin author, it would be nice to "git blame" the version number of my plugins to see when they were updated automatically by the script.  By ensuring the plugins.json always emit in the same order, we clean up the diffs.

---

Example:
Before, HelloWorldNodeJS is on line 2768.  After it's on line 2.
https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/commit/7e5550fbc32dce182447d62cbd26622f607ea549#diff-18d7f9b905f83805c42db6d239a7fb0207d4b32193202eb13ba077caed424c3cR395