### PR TITLE
Add Shortcut Plugin

### DIFF
--- a/plugins/Shortcut-flow.launcher.plugin.shortcut.json
+++ b/plugins/Shortcut-flow.launcher.plugin.shortcut.json
@@ -6,7 +6,7 @@
     "Version": "1.0.0",
     "Language": "TypeScript",
     "Website": "https://github.com/mikegyi/flow-launcher-shortcut",
-    "UrlDownload": "https://github.com/mikegyi/flow-launcher-shortcut/releases/latest/download/Flow.Launcher.Plugin.Shortcut.zip",
+    "UrlDownload": "https://github.com/mikegyi/flow-launcher-shortcut/releases/download/v1.0.0/Flow.Launcher.Plugin.Shortcut.zip",
     "UrlSourceCode": "https://github.com/mikegyi/flow-launcher-shortcut",
     "IcoPath": "https://cdn.jsdelivr.net/gh/mikegyi/flow-launcher-shortcut/Images/app.png"
   }

--- a/plugins/Shortcut-flow.launcher.plugin.shortcut.json
+++ b/plugins/Shortcut-flow.launcher.plugin.shortcut.json
@@ -1,0 +1,12 @@
+{
+    "ID": "flow.launcher.plugin.shortcut",  
+    "Name": "Shortcut",
+    "Description": "Search and create stories in Shortcut (formerly Clubhouse)",
+    "Author": "Mike Gyi",
+    "Version": "1.0.0",
+    "Language": "TypeScript",
+    "Website": "https://github.com/mikegyi/flow-launcher-shortcut",
+    "UrlDownload": "https://github.com/mikegyi/flow-launcher-shortcut/releases/latest/download/Flow.Launcher.Plugin.Shortcut.zip",
+    "UrlSourceCode": "https://github.com/mikegyi/flow-launcher-shortcut",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/mikegyi/flow-launcher-shortcut/Images/app.png"
+  }


### PR DESCRIPTION
   This PR adds the Shortcut plugin which allows Flow Launcher users to:
   - Search and create stories in Shortcut (formerly Clubhouse)
   - Plugin is built with TypeScript
   - Automated releases are set up via GitHub Actions