### PR TITLE
add plugin release webhook notification

### DIFF
--- a/.github/workflows/python-passed.yml
+++ b/.github/workflows/python-passed.yml
@@ -24,8 +24,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ./ci/envs/requirements-update-tested.txt
       - name: Run script
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python ./ci/src/update-tested.py ${{ secrets.DISCORD_WEBHOOK }}
       - name: Update plugin manifest
         if: success()

--- a/.github/workflows/python-passed.yml
+++ b/.github/workflows/python-passed.yml
@@ -19,8 +19,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./ci/envs/requirements-update-tested.txt
       - name: Run script
-        run: python ./ci/src/update-tested.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python ./ci/src/update-tested.py ${{ secrets.DISCORD_WEBHOOK }}
       - name: Update plugin manifest
         if: success()
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/ci/envs/requirements-update-tested.txt
+++ b/ci/envs/requirements-update-tested.txt
@@ -1,0 +1,2 @@
+aiohttp
+tqdm

--- a/ci/src/_utils.py
+++ b/ci/src/_utils.py
@@ -30,6 +30,7 @@ plugin_name = "Name"
 github_url = "https://github.com"
 release_date = "LatestReleaseDate"
 date_added = "DateAdded"
+website = "Website"
 
 # typing
 PluginType = Dict[str, str]

--- a/ci/src/discord.py
+++ b/ci/src/discord.py
@@ -96,16 +96,3 @@ def truncate_release_notes(url: str, release_notes: str, length: int = MAX_BODY_
     graceful_truncation_index = last_included_newline if last_included_newline != -1 else rough_truncation_index
     
     return release_notes[:graceful_truncation_index] + TRUNCATION_MESSAGE
-
-async def send_notification(
-    info: PluginType, latest_ver, release, webhook_url: str | None = None
-) -> None:
-    if not webhook_url:
-        return
-    
-    if version_tuple(info[version]) != version_tuple(latest_ver):
-        tqdm.write(f"Update detected: {info[plugin_name]} {latest_ver}")
-        try:
-            await update_hook(webhook_url, info, latest_ver, release)
-        except Exception as e:
-            tqdm.write(str(e))

--- a/ci/src/update-tested.py
+++ b/ci/src/update-tested.py
@@ -1,31 +1,29 @@
 import asyncio
 from datetime import datetime, UTC
 from sys import argv
-from os import getenv
-from _utils import plugin_reader, plugin_writer, date_added, etag_reader
-from updater import batch_github_plugin_info
+from _utils import plugin_reader, plugin_writer, date_added
+from discord import release_hook
 
 
 async def update_tested():
     webhook_url = None
     if len(argv) > 1:
         webhook_url = argv[1]
-    github_token = getenv("GITHUB_TOKEN")
 
     plugin_infos = plugin_reader()
-    etags = etag_reader()
 
     for idx, plugin in enumerate(plugin_infos):
         if plugin["Language"] == "python" and "Tested" not in plugin.keys():
             plugin_infos[idx]["Tested"] = True
+
         # Add date added if field is not present
         if plugin.get(date_added) is None:
             plugin_infos[idx][date_added] = datetime.now(UTC).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
-            await batch_github_plugin_info(
-                plugin, etags, github_token, webhook_url, True
-            )
+
+            if webhook_url:
+                await release_hook(webhook_url, plugin)
 
     plugin_writer(plugin_infos)
 

--- a/ci/src/update-tested.py
+++ b/ci/src/update-tested.py
@@ -2,23 +2,38 @@ import sys
 import json
 import os
 import zipfile
-import io
-from datetime import datetime
+import io, asyncio, aiohttp
+from datetime import datetime, UTC
+from sys import argv
+from os import getenv
+from _utils import clean, id_name, language_list, version, plugin_reader, plugin_writer, release_date, date_added, etag_reader, PluginType, ETagsType
+from updater import batch_github_plugin_info
+from discord import release_hook
 
-from _utils import clean, id_name, language_list, language_name, plugin_reader, plugin_writer, release_date, date_added
+def update_tested():
+    webhook_url = None
+    if len(argv) > 1:
+        webhook_url = argv[1]
+    github_token = getenv("GITHUB_TOKEN")
 
-if __name__ == "__main__":
     plugin_infos = plugin_reader()
+    etags = etag_reader()
 
     for idx, plugin in enumerate(plugin_infos):
         if plugin["Language"] == "python" and "Tested" not in plugin.keys():
             plugin_infos[idx]["Tested"] = True
         # Add date added if field is not present
         if plugin.get(date_added) is None:
-            plugin_infos[idx][date_added] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+            plugin_infos[idx][date_added] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            yield batch_github_plugin_info(plugin, etags, github_token, webhook_url, True)
+    
     plugin_writer(plugin_infos)
 
+async def main():
+    await asyncio.gather(*update_tested())
 
+if __name__ == '__main__':
+    asyncio.run(main())
 
 
 

--- a/ci/src/update-tested.py
+++ b/ci/src/update-tested.py
@@ -1,14 +1,10 @@
-import sys
-import json
-import os
-import zipfile
-import io, asyncio
+import asyncio
 from datetime import datetime, UTC
 from sys import argv
 from os import getenv
-from _utils import clean, id_name, language_list, version, plugin_reader, plugin_writer, release_date, date_added, etag_reader, PluginType, ETagsType
+from _utils import plugin_reader, plugin_writer, date_added, etag_reader
 from updater import batch_github_plugin_info
-from discord import release_hook
+
 
 async def update_tested():
     webhook_url = None
@@ -24,15 +20,15 @@ async def update_tested():
             plugin_infos[idx]["Tested"] = True
         # Add date added if field is not present
         if plugin.get(date_added) is None:
-            plugin_infos[idx][date_added] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-            await batch_github_plugin_info(plugin, etags, github_token, webhook_url, True)
-    
+            plugin_infos[idx][date_added] = datetime.now(UTC).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            await batch_github_plugin_info(
+                plugin, etags, github_token, webhook_url, True
+            )
+
     plugin_writer(plugin_infos)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     asyncio.run(update_tested())
-
-
-
-
-

--- a/ci/src/update-tested.py
+++ b/ci/src/update-tested.py
@@ -2,7 +2,7 @@ import sys
 import json
 import os
 import zipfile
-import io, asyncio, aiohttp
+import io, asyncio
 from datetime import datetime, UTC
 from sys import argv
 from os import getenv
@@ -10,7 +10,7 @@ from _utils import clean, id_name, language_list, version, plugin_reader, plugin
 from updater import batch_github_plugin_info
 from discord import release_hook
 
-def update_tested():
+async def update_tested():
     webhook_url = None
     if len(argv) > 1:
         webhook_url = argv[1]
@@ -25,15 +25,12 @@ def update_tested():
         # Add date added if field is not present
         if plugin.get(date_added) is None:
             plugin_infos[idx][date_added] = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
-            yield batch_github_plugin_info(plugin, etags, github_token, webhook_url, True)
+            await batch_github_plugin_info(plugin, etags, github_token, webhook_url, True)
     
     plugin_writer(plugin_infos)
 
-async def main():
-    await asyncio.gather(*update_tested())
-
 if __name__ == '__main__':
-    asyncio.run(main())
+    asyncio.run(update_tested())
 
 
 

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -13,7 +13,7 @@ from _utils import *
 from discord import send_notification
 
 async def batch_github_plugin_info(
-    info: P, tags: ETagsType, github_token=None, webhook_url: str | None = None, is_release_noti: bool = False
+    info: P, tags: ETagsType, github_token=None, webhook_url: str | None = None
 ) -> P:
     try:
         headers = {"authorization": f"token {github_token}"}
@@ -48,7 +48,7 @@ async def batch_github_plugin_info(
                 info[url_download] = assets[0]["browser_download_url"]
                 if webhook_url:
                     await send_notification(
-                        info, clean(latest_rel["tag_name"], "v"), latest_rel, webhook_url, is_release_noti
+                        info, clean(latest_rel["tag_name"], "v"), latest_rel, webhook_url
                     )
                 info[version] = clean(latest_rel["tag_name"], "v")
 

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -10,7 +10,7 @@ import traceback
 from tqdm.asyncio import tqdm
 
 from _utils import *
-from discord import send_notification
+from discord import update_hook
 
 async def batch_github_plugin_info(
     info: P, tags: ETagsType, github_token=None, webhook_url: str | None = None
@@ -87,6 +87,20 @@ def remove_unused_etags(plugin_infos: PluginsType, etags: ETagsType) -> ETagsTyp
         etags_updated[id] = tag
 
     return etags_updated
+
+
+async def send_notification(
+    info: PluginType, latest_ver, release, webhook_url: str | None = None
+) -> None:
+    if not webhook_url:
+        return
+    
+    if version_tuple(info[version]) != version_tuple(latest_ver):
+        tqdm.write(f"Update detected: {info[plugin_name]} {latest_ver}")
+        try:
+            await update_hook(webhook_url, info, latest_ver, release)
+        except Exception as e:
+            tqdm.write(str(e))
 
 async def main():
     webhook_url = None


### PR DESCRIPTION
Based on #420 

This PR adds a notification that gets triggered in the `python-passed.yml` workflow, where when the `DateAdded` key gets added to a plugin, a notification is sent to discord stating that a new plugin has been uploaded. I tried to keep the embed similar to the one used for updates, but I made a couple of changes.

## Notification Example
![image](https://private-user-images.githubusercontent.com/71997063/409772853-9d741be8-5316-45ed-b3ef-6aa2f548dbc8.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Mzg3MTYyMjMsIm5iZiI6MTczODcxNTkyMywicGF0aCI6Ii83MTk5NzA2My80MDk3NzI4NTMtOWQ3NDFiZTgtNTMxNi00NWVkLWIzZWYtNmFhMmY1NDhkYmM4LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAyMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMjA1VDAwMzg0M1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE4NzQ1MmJkOTU0YjgwNTk0NWM0OTg2OTExMTk3Yzc2N2ZjNGI3ZmRmMDY3YzE1YmRiZDNiOGU4YmY0ODc3NzAmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.ssM_gmEBVR4iz3790k2F5PIMcn85IZy5han114_xxXw)

## Overview of changes
1. Added requirements to the `update-tested.py` script and `python-passed.yml` workflow
2. added a `release_hook` function based on `update_hook` to `discord.py`
3. have `update-tested.py` execute `release_hook` for new releases
4. Added webhook_url to `update-tested.py` via a CLI argument 
5. I also fixed a couple of typehints so that my typechecker would stop yelling at me