### PR TITLE
Validate download url in `validator.py`

### DIFF
--- a/ci/src/_utils.py
+++ b/ci/src/_utils.py
@@ -8,6 +8,10 @@ from typing import Dict, List, TypeVar
 # If adding a third-party library here, check CI workflows Python files
 # that are dependant on this and require pip install.
 
+github_download_url_regex = re.compile(
+    r"https://github\.com/(?P<author>[a-zA-Z0-9-]+)/(?P<repo>[a-zA-Z0-9\.\-\_]*)/releases/download/(?P<version>[a-zA-Z\.0-9]+)/(?P<filename>.*)\.zip"
+)
+
 # path
 utils_path = Path(__file__).resolve()
 

--- a/ci/src/updater.py
+++ b/ci/src/updater.py
@@ -14,11 +14,6 @@ from tqdm.asyncio import tqdm
 from _utils import *
 from discord import update_hook
 
-github_download_url_regex = re.compile(
-    r"https://github\.com/(?P<author>[a-zA-Z0-9-]+)/(?P<repo>[a-zA-Z0-9\.\-\_]*)/releases/download/(?P<version>[a-zA-Z\.0-9]+)/(?P<filename>.*)\.zip"
-)
-
-
 async def batch_github_plugin_info(
     info: P, tags: ETagsType, github_token=None, webhook_url: str | None = None
 ) -> P:

--- a/ci/src/validator.py
+++ b/ci/src/validator.py
@@ -2,7 +2,7 @@
 import uuid
 
 from _utils import (check_url, clean, get_new_plugin_submission_ids, get_plugin_file_paths, get_plugin_filenames,
-                    icon_path, id_name, language_list, language_name, plugin_reader)
+                    icon_path, id_name, language_list, language_name, plugin_reader, github_download_url_regex, url_download)
 
 plugin_infos = plugin_reader()
 
@@ -52,3 +52,7 @@ def test_submitted_plugin_id_is_valid_uuid():
             outcome = False
 
         assert outcome is True, f"The submission plugin ID {id} is not a valid v4 UUID"
+
+def test_valid_download_url():
+    for info in plugin_infos:
+        assert github_download_url_regex.fullmatch(info[url_download]), f" The plugin {info['Name']}-{info['ID']} does not have a valid download url: {info[url_download]}"


### PR DESCRIPTION
I've noticed quite a few plugin submissions with the download url set to the releases page of their github repo, so this PR simply adds a test to `validator.py` that validates the download url using the download url regex introduced in #462.