### PR TITLE
New Plugin: CHZZK

### DIFF
--- a/plugins/CHZZK-517b8920fe5647e284c29089749ab69b.json
+++ b/plugins/CHZZK-517b8920fe5647e284c29089749ab69b.json
@@ -1,0 +1,12 @@
+{
+  "ID": "517b8920fe5647e284c29089749ab69b",
+  "Name": "CHZZK",
+  "Description": "Watch CHZZK conveniently.",
+  "Author": "yckim",
+  "Version": "1.1.2",
+  "Language": "typescript",
+  "Website": "https://github.com/kim0chan/Flow.Launcher.Plugin.CHZZK",
+  "UrlDownload": "https://github.com/kim0chan/Flow.Launcher.Plugin.CHZZK/releases/download/v1.1.2/Flow.Launcher.Plugin.CHZZK.zip",
+  "UrlSourceCode": "https://github.com/kim0chan/Flow.Launcher.Plugin.CHZZK/tree/main",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/kim0chan/Flow.Launcher.Plugin.CHZZK@v1.1.2/packages/plugin/images/app.png"
+}


### PR DESCRIPTION
**New Plugin: CHZZK**

Hi there!

This PR adds a new plugin for CHZZK (https://chzzk.naver.com/), a popular video streaming platform in South Korea.

This plugin allows users to conveniently search for channels and livestreams on CHZZK using its official open API, right from the Flow Launcher.

**Key Features**
- **Search Live Streams**: Quickly find and open ongoing livestreams.
- **Search Channels**: Look up your favorite streamers' channels.
- **Secure API Usage**: To protect the necessary API credentials (`Client ID` and `Client Secret`), this plugin utilizes a self-hostable reverse proxy built with Cloudflare Workers. The source code for this proxy is included within this repository, ensuring transparency and security for users.

I believe this plugin will be a great addition for many Korean users of Flow Launcher.

Thank you for your consideration!