### PR TITLE
Switch default branch from plugin_api_v2 to main branch

### DIFF
--- a/.github/workflows/python-passed.yml
+++ b/.github/workflows/python-passed.yml
@@ -1,7 +1,7 @@
 name: Update tested plugins
 on:
   push:
-    branches: [ plugin_api_v2 ]
+    branches: [ main ]
     paths:
       - 'plugins.json'
 jobs:
@@ -31,4 +31,4 @@ jobs:
         with:
           commit_message: "Update Tested plugins"
           push_options: --force
-          branch: plugin_api_v2
+          branch: main

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -38,4 +38,4 @@ jobs:
         with:
           commit_message: "auto updated plugins"
           push_options: --force
-          branch: plugin_api_v2
+          branch: main

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Website
 
 on:
   push:
-    branches: [ plugin_api_v2 ]
+    branches: [ main ]
     paths:
       - 'plugins.json'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the information for community-made plugins used in [Flow](https://github.com/Flow-Launcher/Flow.Launcher) and how to make new submissions.
 
-[![AutoUpdate](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml/badge.svg?branch=plugin_api_v2)](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml)
+[![AutoUpdate](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml/badge.svg?branch=main)](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/workflows/updater.yaml)
 
 ## Plugin list
 
@@ -10,7 +10,7 @@ Looking for a list of currently available plugins in Flow? Visit [here](https://
 
 ## How to submit your plugin
 
-1. Create a file named `${name}-${uuid}.json` in the [plugins](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/tree/plugin_api_v2/plugins) directory.
+1. Create a file named `${name}-${uuid}.json` in the [plugins](https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/tree/main/plugins) directory.
 2. Copy these items from your plugin project's `plugin.json` file:
    - `ID`
    - `Name`


### PR DESCRIPTION
Switch default branch from plugin_api_v2 to main branch

All PRs and GitHub actions are to run from main and not plugin_api_v2 branch.
All users will need to update to flow v2.0.0 to recieve new plugins and updates. 
Installing v2.0.0 default plugins e.g. Calculator, Browser Bookmark, Explorer, and so on while on older flow version will crash.

From https://github.com/Flow-Launcher/Flow.Launcher/pull/3933

