### PR TITLE
Add Dialog Jump Files plugin

### DIFF
--- a/plugins/Dialog Jump Files-09f22573-52b9-433b-832e-450e2f91093b.json
+++ b/plugins/Dialog Jump Files-09f22573-52b9-433b-832e-450e2f91093b.json
@@ -1,0 +1,12 @@
+{
+    "ID": "09f22573-52b9-433b-832e-450e2f91093b",
+    "Name": "Dialog Jump Files",
+    "Description": "Use Files as third-party explorer for dialog jump feature in Flow Launcher",
+    "Author": "Jack251970",
+    "Version": "1.0.0",
+    "Language": "csharp",
+    "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.DialogJump.Files",
+    "UrlDownload": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.DialogJump.Files/releases/download/v1.0.0/Dialog.Jump.Files-1.0.0.zip",
+    "UrlSourceCode": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.DialogJump.Files/tree/master",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/Flow-Launcher/Flow.Launcher.Plugin.DialogJump.Files@master/src/Images/icon.png"
+}


### PR DESCRIPTION
Use [Files](https://github.com/files-community/Files) as third-party explorer for dialog jump feature in Flow Launcher

Ported from: [Listary.FileAppPlugin.Files](https://github.com/files-community/Listary.FileAppPlugin.Files)

Tested with Files v4.0.0 and Flow v2.0.0