### PR TITLE
switch all imgur links for cdn.jsdelivr.net links

### DIFF
--- a/plugins/Firefox Keyword Bookmarks-bb3ca236-f416-46d5-b88b-597748c33dce.json
+++ b/plugins/Firefox Keyword Bookmarks-bb3ca236-f416-46d5-b88b-597748c33dce.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.FirefoxKeywordBookmarks/tree/v0.2.2",
     "UrlDownload": "https://github.com/cibere/FirefoxKeywordBookmarks/releases/download/v0.2.3/FirefoxKeywordBookmarks.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.FirefoxKeywordBookmarks",
-    "IcoPath": "https://i.imgur.com/1cGHQTp.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/FirefoxKeywordBookmarks/assets/app.png",
     "LatestReleaseDate": "2025-02-09T22:12:13Z",
     "Tested": true,
     "DateAdded": "2024-10-31T12:40:23Z"

--- a/plugins/Flow Load Notification-5f48576d-efe7-4562-a4ed-fe64455f1ac1.json
+++ b/plugins/Flow Load Notification-5f48576d-efe7-4562-a4ed-fe64455f1ac1.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.FlowLoadNotification",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.FlowLoadNotification/releases/download/v0.0.6/Flow.Launcher.Plugin.FlowLoadNotification.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.FlowLoadNotification",
-    "IcoPath": "https://i.imgur.com/G0lVumf.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.FlowLoadNotification/assets/app.png",
     "LatestReleaseDate": "2025-09-08T04:02:06Z",
     "DateAdded": "2024-11-24T12:38:14Z"
 }

--- a/plugins/ScreenBrightness-eb0c1059-1824-4fa6-b04e-aaeb4303cbe1.json
+++ b/plugins/ScreenBrightness-eb0c1059-1824-4fa6-b04e-aaeb4303cbe1.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.ScreenBrightness",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.ScreenBrightness/releases/download/v0.0.10/Flow.Launcher.Plugin.ScreenBrightness.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.ScreenBrightness",
-    "IcoPath": "https://i.imgur.com/AvRgwSl.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.ScreenBrightness/assets/app.png",
     "LatestReleaseDate": "2025-07-08T12:36:25Z",
     "DateAdded": "2024-12-22T01:45:40Z"
 }

--- a/plugins/Steam Account Switcher-5314722CF6AA4EBF86666C693412A276.json
+++ b/plugins/Steam Account Switcher-5314722CF6AA4EBF86666C693412A276.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.SteamAccountSwitcher",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.SteamAccountSwitcher/releases/download/v1.0.3/Flow.Launcher.Plugin.SteamAccountSwitcher.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.SteamAccountSwitcher",
-    "IcoPath": "https://i.imgur.com/7kxy2JP.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.SteamAccountSwitcher/Images/app.png",
     "LatestReleaseDate": "2024-11-18T00:02:20Z",
     "Tested": true,
     "DateAdded": "2024-11-21T09:23:24Z"

--- a/plugins/Wordle-32dcd763-f8ad-4f14-b000-fcf0884f0093.json
+++ b/plugins/Wordle-32dcd763-f8ad-4f14-b000-fcf0884f0093.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.Wordle",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.Wordle/releases/download/v0.1.1/Flow.Launcher.Plugin.Wordle.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.Wordle",
-    "IcoPath": "https://i.imgur.com/5OWWgvq.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.Wordle/assets/app.png",
     "LatestReleaseDate": "2025-10-06T20:18:28Z",
     "DateAdded": "2024-12-01T12:40:10Z"
 }

--- a/plugins/Wordnik Dictionary-7ed41d7e3d174379972e1cdacb647474.json
+++ b/plugins/Wordnik Dictionary-7ed41d7e3d174379972e1cdacb647474.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.WordNikDictionary/tree/v2.1.0",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.WordNikDictionary/releases/download/v2.1.0/Flow.Launcher.Plugin.WordNikDictionary.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.WordNikDictionary/tree/main",
-    "IcoPath": "https://i.imgur.com/VTVaFuF.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.WordNikDictionary/Images/app.png",
     "LatestReleaseDate": "2024-10-28T03:23:35Z",
     "Tested": true,
     "DateAdded": "2024-10-26T21:17:53Z"

--- a/plugins/rtfm-bd4aff8b-108f-4ce9-affb-57c736648fe7.json
+++ b/plugins/rtfm-bd4aff8b-108f-4ce9-affb-57c736648fe7.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/cibere/Flow.Launcher.Plugin.rtfm",
     "UrlDownload": "https://github.com/cibere/Flow.Launcher.Plugin.rtfm/releases/download/v1.4.5/Flow.Launcher.Plugin.rtfm.zip",
     "UrlSourceCode": "https://github.com/cibere/Flow.Launcher.Plugin.rtfm",
-    "IcoPath": "https://i.imgur.com/cvI93QW.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/cibere/Flow.Launcher.Plugin.rtfm/assets/app.png",
     "LatestReleaseDate": "2025-09-08T04:03:49Z",
     "DateAdded": "2024-12-20T12:39:36Z"
 }


### PR DESCRIPTION
Imgur can act weirdly, and I sometimes notice that they don't load anywhere near as quickly as the other links. So, since my plugins were the only ones using imgur links, I switched all of them to use cdn.jsdelivr.net links instead