### PR TITLE
Update Amazing Marvin IcoPath URL to use CDN

### DIFF
--- a/plugins/Amazing Marvin-90f799c3-c04e-443b-bce8-eec5fbcba1e9.json
+++ b/plugins/Amazing Marvin-90f799c3-c04e-443b-bce8-eec5fbcba1e9.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/rrFlowLauncher/amazing_marvin/",
     "UrlDownload": "https://github.com/rrFlowLauncher/amazing_marvin/releases/download/v0.2.0/amazing_marvin.zip",
     "UrlSourceCode": "https://github.com/rrFlowLauncher/amazing_marvin",
-    "IcoPath": "https://github.com/rrFlowLauncher/amazing_marvin/blob/main/Images/Amazing_Marvin.09233c09.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/rrFlowLauncher/amazing_marvin@main/Images/Amazing_Marvin.09233c09.png",
     "Tested": true,
     "DateAdded": "2023-12-16T06:48:43Z",
     "LatestReleaseDate": "2023-11-23T19:45:12Z"


### PR DESCRIPTION
Icon doesn't seem to show on the plugin list site, use CDN to fix it.