### PR TITLE
feat: Add GitHub Repository Viewer Plugin

### DIFF
--- a/plugins/GitHub Repository Viewer-162D050FCC554C78B4AAD612C910E63D.json
+++ b/plugins/GitHub Repository Viewer-162D050FCC554C78B4AAD612C910E63D.json
@@ -1,0 +1,12 @@
+{
+    "ID": "162D050FCC554C78B4AAD612C910E63D",
+    "Name": "GitHub Repository Viewer",
+    "Description": "A Flow Launcher plugin to quickly navigate to your personal repositories",
+    "Author": "RudraPatel2003",
+    "Version": "1.0.0",
+    "Language": "csharp",
+    "Website": "https://github.com/RudraPatel2003/github-repository-viewer",
+    "UrlDownload": "https://github.com/RudraPatel2003/github-repository-viewer/releases/download/v1.0.0/Flow.Plugin.GitHubRepositoryViewer-1.0.0.zip",
+    "UrlSourceCode": "https://github.com/RudraPatel2003/github-repository-viewer",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/RudraPatel2003/github-repository-viewer@main/Flow.Launcher.Plugin.GitHubRepositoryViewer/Assets/icon.png"
+}


### PR DESCRIPTION
This PR adds the GitHub Repository Viewer Plugin

This plugin solves the problem of being able to quickly navigate to GitHub repositories that you are the owner of. 

For example, I want to be able to type `gh scf` and be able to go to `https://github.com/hack4impact-utk/st-christopher-truckers-relief-fund` in my browser (for context I am a part of the hack4impact-utk organization so it would appear when fetching repos with my token)

There are 3 other GitHub related plugins on the Flow Launcher store

1. GitHub Notifications, which isn't related to the problem
2. GitHub, which makes API requests every time you search
3. GitHub Quick Launcher, which does let you go to personal repos but again has to make API requests (and is very slow, it can take like 5 seconds to resolve the query for some reason)

This plugin pre-fetches all repos that you own and lets you very quickly navigate to them with fuzzy searching. You can also exclude organizations to hide their repositories in the results (useful if you are in university and in class organizations with 50+ repositories)