### PR TITLE
feat Add Repository Quick Launcher

### DIFF
--- a/plugins/Repository Quick Launcher-D0F4498BC725495FBCAB8B5046818671.json
+++ b/plugins/Repository Quick Launcher-D0F4498BC725495FBCAB8B5046818671.json
@@ -1,7 +1,7 @@
 {
   "ID": "D0F4498BC725495FBCAB8B5046818671",
   "Name": "Repository Quick Launcher",
-  "Description": "A Flow Launcher plugin to quickly open codebases using VS Code or Cursor",
+  "Description": "A Flow Launcher plugin to quickly open codebases using your IDE of choice (VSCode, Cursor, Zed, etc.)",
   "Author": "RudraPatel2003",
   "Version": "1.0.0",
   "Language": "csharp",


### PR DESCRIPTION
This PR adds the Repository Quick Launcher plugin

There are existing plugins for VSCode workspaces and Cursor workspaces but
1. They rely on workspaces, and these have a pretty sticky memory. If you open a certain folder at a path and then move where it is and open it again, there are now two workspaces with different paths. One will work and one won't. This gets worse if you move it around even more. Workspaces can also become crowded when you work with lots of repos.
2. If you have a lot of repositories then it can be harder to search for all of them.
3. You need a plugin for every IDE

This plugin takes a modified approach
First, you define the folders in Windows or WSL that you want the plugin to scan and the launch commands for Windows and WSL
On load, the plugin will load information about each directory in the folders you specified

The logic behind this is that as a developer I clone most of my repos into central folders (/git in WSL or C:\git in Windows). If I open some other random folders in VSCode I don't want that appearing in my search