### PR TITLE
Add `Windows Services Manager` plugin

### DIFF
--- a/plugins/Windows Services Manager-42f63e8d-3d3d-4b4b-9e91-c6094bf240ec.json
+++ b/plugins/Windows Services Manager-42f63e8d-3d3d-4b4b-9e91-c6094bf240ec.json
@@ -1,0 +1,12 @@
+{
+  "ID": "42f63e8d-3d3d-4b4b-9e91-c6094bf240ec",
+  "Name": "Windows Services Manager",
+  "Description": "Manage Windows services from Flow Launcher",
+  "Author": "TBM13",
+  "Version": "1.1.1",
+  "Language": "csharp",
+  "Website": "https://github.com/TBM13/Flow.Launcher.Plugin.WindowsServices",
+  "UrlDownload": "https://github.com/TBM13/Flow.Launcher.Plugin.WindowsServices/releases/download/v1.1.1/Flow.Launcher.Plugin.WindowsServices.zip",
+  "UrlSourceCode": "https://github.com/TBM13/Flow.Launcher.Plugin.WindowsServices", 
+  "IcoPath": "https://cdn.jsdelivr.net/gh/TBM13/Flow.Launcher.Plugin.WindowsServicesManager@main/Flow.Launcher.Plugin.WindowsServices/Images/app.png"
+}


### PR DESCRIPTION
A Windows Services plugin already exists (https://www.flowlauncher.com/plugins/window-services/) but it hasn't been updated since 2022, requires Python, it's very slow and lacks features like enabling/disabling services and showing their description.

Thus, I made this plugin. More information and screenshots on its repository (https://github.com/TBM13/Flow.Launcher.Plugin.WindowsServices).