### PR TITLE
Add Speed Test plugin

### DIFF
--- a/plugins/Speed Test-9E4A2B3C-5F6D-4E8A-9B1C-2D3E4F5A6B7C.json
+++ b/plugins/Speed Test-9E4A2B3C-5F6D-4E8A-9B1C-2D3E4F5A6B7C.json
@@ -6,7 +6,7 @@
     "Version": "1.0.0",
     "Language": "csharp",
     "Website": "https://github.com/swopnil7/Flow.Launcher.Plugin.SpeedTest",
-    "UrlDownload": "https://github.com/swopnil7/Flow.Launcher.Plugin.SpeedTest/releases/download/v1.0.0/SpeedTest-1.0.0.zip",
+    "UrlDownload": "https://github.com/swopnil7/Flow.Launcher.Plugin.SpeedTest/releases/download/v1.0.0/Flow.Launcher.Plugin.SpeedTest-1.0.0.zip",
     "UrlSourceCode": "https://github.com/swopnil7/Flow.Launcher.Plugin.SpeedTest",
     "IcoPath": "https://cdn.jsdelivr.net/gh/swopnil7/Flow.Launcher.Plugin.SpeedTest@main/icon.png"
 }


### PR DESCRIPTION
Test your internet speed from Flow Launcher using the Ookla Speedtest CLI.
## Features
- **Type** `st` to run a speed test (no extra setup). ⚡
- **Live progress:** shows download/upload progress while the test runs. ⏱️
- **Results:** final download/upload speeds, ping, jitter, and server/ISP info.📊