### PR TITLE
Add PR assignment workflow for pull request creators

### DIFF
--- a/.github/workflows/pr_assignee.yml
+++ b/.github/workflows/pr_assignee.yml
@@ -1,0 +1,17 @@
+name: Assign PR to creator
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches-ignore:
+      - l10n_dev
+
+permissions:
+  pull-requests: write
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assign PR to creator
+      uses: toshimaru/auto-author-assign@v3.0.1


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automatically assign newly opened pull requests to their creator. This helps streamline the review process by ensuring the author is clearly identified as responsible for the PR.

Automation and workflow improvements:

* Added a `.github/workflows/pr_assignee.yml` workflow that triggers on new pull requests (excluding the `l10n_dev` branch) and uses the `toshimaru/auto-author-assign` action to assign the PR to its creator.