### PR TITLE
Add Command Vault plugin

### DIFF
--- a/plugins/Command Vault-19132E4B-9100-4E97-BDD2-92415B78D23D.json
+++ b/plugins/Command Vault-19132E4B-9100-4E97-BDD2-92415B78D23D.json
@@ -3,10 +3,10 @@
     "Name": "Command Vault",
     "Description": "Search and copy commands from a structured local vault. Supports categories (Cisco, Linux, Proxmox, Ansible), fuzzy search, favorites and templates with variables.",
     "Author": "BossFlap",
-    "Version": "1.1.1",
+    "Version": "1.1.2",
     "Language": "python",
     "Website": "https://github.com/BossFlap/flow-command-vault",
     "IcoPath": "https://cdn.jsdelivr.net/gh/BossFlap/flow-command-vault@master/Images/icon.png",
     "UrlSourceCode": "https://github.com/BossFlap/flow-command-vault",
-    "UrlDownload": "https://github.com/BossFlap/flow-command-vault/releases/download/v1.1.1/CommandVault-1.1.1.zip"
+    "UrlDownload": "https://github.com/BossFlap/flow-command-vault/releases/download/v1.1.2/CommandVault-1.1.2.zip"
 }


### PR DESCRIPTION
## Command Vault

A 1Password-style command launcher for network and system admins.

- **Author:** BossFlap
- **Language:** Python
- **Keyword:** `cv`
- **Source:** https://github.com/BossFlap/flow-command-vault
- **Download:** https://github.com/BossFlap/flow-command-vault/releases/download/v1.0.0/CommandVault-1.0.0.zip

### Features
- 156 built-in commands: Cisco IOS, Linux, Proxmox, Ansible
- Full-text search (FTS5) with LIKE fallback
- Favorites system
- Template variables with interactive prompts
- Built-in GUI manager (`cv :manage`)
- SQLite backend, MIT license