### PR TITLE
Fix UrlSourceCode for Jira Search and Confluence Search to unblock auto-updater

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -4401,7 +4401,7 @@
         "Language": "csharp",
         "Website": "https://github.com/haugjan/Flow.JiraSearch",
         "UrlDownload": "https://github.com/haugjan/Flow.JiraSearch/releases/download/v1.1.0/JiraSearch-1.1.0.zip",
-        "UrlSourceCode": "https://github.com/haugjan/Flow.JiraSearch.git",
+        "UrlSourceCode": "https://github.com/haugjan/Flow.JiraSearch",
         "IcoPath": "https://cdn.jsdelivr.net/gh/haugjan/Flow.JiraSearch@main/Flow.JiraSearch/Images/icon.png",
         "LatestReleaseDate": null,
         "DateAdded": "2025-10-22T01:53:34Z"

--- a/plugins.json
+++ b/plugins.json
@@ -2189,7 +2189,7 @@
         "Language": "csharp",
         "Website": "https://github.com/haugjan/Flow.ConfluenceSearch",
         "UrlDownload": "https://github.com/haugjan/Flow.ConfluenceSearch/releases/download/v1.0.1/ConfluenceSearch-1.0.1.zip",
-        "UrlSourceCode": "https://github.com/haugjan/Flow.ConfluenceSearch.git",
+        "UrlSourceCode": "https://github.com/haugjan/Flow.ConfluenceSearch",
         "IcoPath": "https://cdn.jsdelivr.net/gh/haugjan/Flow.ConfluenceSearch@5d347ac7a5594cc4e468771eecee97d706f1d6bf/Flow.ConfluenceSearch/Images/icon.png",
         "LatestReleaseDate": null,
         "DateAdded": "2025-11-18T12:51:16Z"

--- a/plugins/Confluence Search-EE691863-50D1-4E0F-9A36-83314C2B2B27.json
+++ b/plugins/Confluence Search-EE691863-50D1-4E0F-9A36-83314C2B2B27.json
@@ -7,7 +7,7 @@
     "Language": "csharp",
     "Website": "https://github.com/haugjan/Flow.ConfluenceSearch",
     "UrlDownload": "https://github.com/haugjan/Flow.ConfluenceSearch/releases/download/v1.0.1/ConfluenceSearch-1.0.1.zip",
-    "UrlSourceCode": "https://github.com/haugjan/Flow.ConfluenceSearch.git",
+    "UrlSourceCode": "https://github.com/haugjan/Flow.ConfluenceSearch",
     "IcoPath": "https://cdn.jsdelivr.net/gh/haugjan/Flow.ConfluenceSearch@5d347ac7a5594cc4e468771eecee97d706f1d6bf/Flow.ConfluenceSearch/Images/icon.png",
     "LatestReleaseDate": null,
     "DateAdded": "2025-11-18T12:51:16Z"

--- a/plugins/FlowOCR-e840a588-fc41-4d80-94a0-88739e529172.json
+++ b/plugins/FlowOCR-e840a588-fc41-4d80-94a0-88739e529172.json
@@ -7,7 +7,7 @@
     "Language": "python",
     "Website": "https://github.com/agostino-code/FlowOCR.git",
     "UrlDownload": "https://github.com/agostino-code/FlowOCR/releases/download/v1.0.2/Flow.Launcher.Plugin.FlowOCR.zip",
-    "UrlSourceCode": "https://github.com/agostino-code/FlowOCR/tree/main",
+    "UrlSourceCode": "https://github.com/agostino-code/FlowOCR",
     "IcoPath": "https://cdn.jsdelivr.net/gh/agostino-code/FlowOCR@main/Images/app.png",
     "LatestReleaseDate": "2026-03-19T23:58:18Z",
     "Tested": true,

--- a/plugins/Guid Converter-27ad17d5-dacb-4732-9653-03def5f86125.json
+++ b/plugins/Guid Converter-27ad17d5-dacb-4732-9653-03def5f86125.json
@@ -7,7 +7,7 @@
     "Language": "csharp",
     "Website": "https://github.com/NDiiong/Flow.Launcher.Plugin.GuidConverter.git",
     "UrlDownload": "https://github.com/NDiiong/Flow.Launcher.Plugin.GuidConverter/releases/download/v1.1.1/Flow.Launcher.Plugin.GuidConverter.zip",
-    "UrlSourceCode": "https://github.com/NDiiong/Flow.Launcher.Plugin.GuidConverter/tree/main",
+    "UrlSourceCode": "https://github.com/NDiiong/Flow.Launcher.Plugin.GuidConverter",
     "IcoPath": "https://cdn.jsdelivr.net/gh/NDiiong/Flow.Launcher.Plugin.GuidConverter@main/Flow.Launcher.Plugin.GuidConverter/Images/icon.png",
     "DateAdded": "2024-01-29T22:14:40Z",
     "LatestReleaseDate": "2024-01-30T02:43:51Z"

--- a/plugins/Jira Search-BD32A62C-6F98-4541-AE8E-17B46458595F.json
+++ b/plugins/Jira Search-BD32A62C-6F98-4541-AE8E-17B46458595F.json
@@ -7,7 +7,7 @@
     "Language": "csharp",
     "Website": "https://github.com/haugjan/Flow.JiraSearch",
     "UrlDownload": "https://github.com/haugjan/Flow.JiraSearch/releases/download/v1.1.0/JiraSearch-1.1.0.zip",
-    "UrlSourceCode": "https://github.com/haugjan/Flow.JiraSearch.git",
+    "UrlSourceCode": "https://github.com/haugjan/Flow.JiraSearch",
     "IcoPath": "https://cdn.jsdelivr.net/gh/haugjan/Flow.JiraSearch@main/Flow.JiraSearch/Images/icon.png",
     "LatestReleaseDate": null,
     "DateAdded": "2025-10-22T01:53:34Z"

--- a/plugins/Windsurf Workspaces-8F9E7D6C5B4A3E2D1C0B9A8F7E6D5C4B.json
+++ b/plugins/Windsurf Workspaces-8F9E7D6C5B4A3E2D1C0B9A8F7E6D5C4B.json
@@ -7,7 +7,7 @@
     "Language": "typescript",
     "Website": "https://github.com/plfavreau/windsurf-flow-launcher-plugin",
     "UrlDownload": "https://github.com/plfavreau/windsurf-flow-launcher-plugin/releases/download/v1.0.0/Flow.Launcher.Plugin.Windsurf.zip",
-    "UrlSourceCode": "https://github.com/plfavreau/windsurf-flow-launcher-plugin.git",
+    "UrlSourceCode": "https://github.com/plfavreau/windsurf-flow-launcher-plugin",
     "IcoPath": "https://cdn.jsdelivr.net/gh/plfavreau/windsurf-flow-launcher-plugin@v1.0.0/icon.png",
     "LatestReleaseDate": null,
     "DateAdded": "2025-12-04T01:58:08Z"


### PR DESCRIPTION
## Summary

Removes the `.git` suffix from `UrlSourceCode` for two plugins by the same author:

- Jira Search (ID `BD32A62C-6F98-4541-AE8E-17B46458595F`)
- Confluence Search (ID `EE691863-50D1-4E0F-9A36-83314C2B2B27`)

## Why

`ci/src/updater.py` derives the GitHub API repo path from `UrlSourceCode`:

```python
url_parts = info[url_sourcecode].split("/")
repo = "/".join(url_parts[3:5])
```

With a value like `"https://github.com/haugjan/Flow.JiraSearch.git"`, this yields `repo = "haugjan/Flow.JiraSearch.git"`, which makes the request resolve to `https://api.github.com/repos/haugjan/Flow.JiraSearch.git/releases/latest` — that endpoint returns 404. The 404 path is not handled explicitly: `latest_rel.get("assets")` returns `None`, the `if assets:` block is skipped, and the function returns the plugin entry unchanged. No exception is raised and no log line is written, so this fails silently.

Symptoms in the manifest for both entries:

- `LatestReleaseDate` is `null` (the updater would otherwise set it on the first successful run)
- `etags.json` holds an empty ETag for the plugin's ID

For Jira Search the manifest is also stuck at `Version: 1.1.0` while the source repo is at `v1.2.0` (published 2025-11-08). Confluence Search happens to be in sync only because its entry was added (2025-11-18) after the latest release was published — any future release would silently be skipped too.

After this change, the next scheduled `Auto Update` run should pick up v1.2.0 for Jira Search and set `LatestReleaseDate` for both entries.

## Possibly worth a follow-up (separate)

It might be worth making `updater.py` strip a trailing `.git` from `UrlSourceCode` before splitting, and/or surfacing non-200/304/403 responses as warnings, so the same problem in other entries does not silently sit there. Happy to file a separate issue if that helps.

## Test plan

- [x] Diff is two single-line `UrlSourceCode` fixes, one per plugin.
- [ ] After merge, the next `Auto Update` workflow run picks up `v1.2.0` for Jira Search and sets `LatestReleaseDate` for both entries.