### PR TITLE
Add Gemini Actions plugin

### DIFF
--- a/plugins/Gemini Actions-F4D7B5C2-3A1E-4F8B-9D6E-2A8C7B4F1E9A.json
+++ b/plugins/Gemini Actions-F4D7B5C2-3A1E-4F8B-9D6E-2A8C7B4F1E9A.json
@@ -1,0 +1,12 @@
+{
+    "ID": "F4D7B5C2-3A1E-4F8B-9D6E-2A8C7B4F1E9A",
+    "Name": "Gemini Actions",
+    "Description": "Run pre-configured Gemini prompts (translate, correct, rewrite ...) against your text and copy the result to the clipboard.",
+    "Author": "Jan Haug",
+    "Version": "1.0.0",
+    "Language": "csharp",
+    "Website": "https://github.com/haugjan/Flow.GeminiActions",
+    "UrlDownload": "https://github.com/haugjan/Flow.GeminiActions/releases/download/v1.0.0/GeminiActions-1.0.0.zip",
+    "UrlSourceCode": "https://github.com/haugjan/Flow.GeminiActions",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/haugjan/Flow.GeminiActions@main/Flow.GeminiActions/Images/icon.png"
+}


### PR DESCRIPTION
Adds the Gemini Actions plugin manifest entry.

- Repo: https://github.com/haugjan/Flow.GeminiActions
- Release: https://github.com/haugjan/Flow.GeminiActions/releases/tag/v1.0.0
- Action keyword: `ask`

Runs pre-configured Gemini prompts (translate, correct, rewrite ...) against the typed text or the current clipboard contents and copies the result to the clipboard.