### PR TITLE
Add Commander Hotlist plugin

### DIFF
--- a/plugins/Commander Hotlist-cecb82f3-6bde-4a1d-b5c6-b4bd3b71d1f1.json
+++ b/plugins/Commander Hotlist-cecb82f3-6bde-4a1d-b5c6-b4bd3b71d1f1.json
@@ -1,0 +1,12 @@
+{
+  "ID": "cecb82f3-6bde-4a1d-b5c6-b4bd3b71d1f1",
+  "Name": "Commander Hotlist",
+  "Description": "Access directory hotlist bookmarks from Total/Double Commander",
+  "Author": "Dani7377",
+  "Version": "1.0.0",
+  "Language": "csharp",
+  "Website": "https://github.com/Dani7377/Flow.Launcher.Plugin.CommanderHotlist",
+  "UrlDownload": "https://github.com/Dani7377/Flow.Launcher.Plugin.CommanderHotlist/releases/download/v1.0.0/Flow.Launcher.Plugin.CommanderHotlist-1.0.0.zip",
+  "UrlSourceCode": "https://github.com/Dani7377/Flow.Launcher.Plugin.CommanderHotlist",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/Dani7377/Flow.Launcher.Plugin.CommanderHotlist@main/Flow.Launcher.Plugin.CommanderHotlist/Images/icon.png"
+}


### PR DESCRIPTION
Added **Commander Hotlist** plugin: Quickly search and access directory hotlist bookmarks from Total/Double Commander.