### PR TITLE
Add QuickTodo plugin

### DIFF
--- a/plugins/QuickTodo-F8A3B1D4E6C2947F5A0B8D3E1C6F2A74.json
+++ b/plugins/QuickTodo-F8A3B1D4E6C2947F5A0B8D3E1C6F2A74.json
@@ -1,0 +1,12 @@
+{
+  "ID": "F8A3B1D4E6C2947F5A0B8D3E1C6F2A74",
+  "Name": "QuickTodo",
+  "Description": "Quick task management with priorities, categories, reminders, and Outlook Tasks support.",
+  "Author": "TrueCrimeAudit",
+  "Version": "1.1.0",
+  "Language": "csharp",
+  "Website": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo",
+  "UrlDownload": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo/releases/download/v1.1.0/Flow.Launcher.Plugin.QuickTodo.zip",
+  "UrlSourceCode": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo@master/Images/todo.png"
+}


### PR DESCRIPTION
Adds QuickTodo, a C# Flow Launcher plugin for lightweight task management with optional Outlook Tasks support.

Release asset: https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo/releases/download/v1.1.0/Flow.Launcher.Plugin.QuickTodo.zip
Source: https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo

Validation performed locally:
- `dotnet build .\Flow.Launcher.Plugin.QuickTodo.csproj`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\Tests\QuickTodo.FlowOutlook.Tests.ps1`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\Tests\QuickTodo.OutlookTasks.Tests.ps1`
- Release workflow completed for `v1.1.0`