### PR TITLE
Add Riot Launcher plugin

### DIFF
--- a/plugins/Riot Launcher-D4D44C2E-2C47-48AC-93E7-5E5C6F5218D8.json
+++ b/plugins/Riot Launcher-D4D44C2E-2C47-48AC-93E7-5E5C6F5218D8.json
@@ -1,0 +1,12 @@
+{
+  "ID": "D4D44C2E-2C47-48AC-93E7-5E5C6F5218D8",
+  "Name": "Riot Launcher",
+  "Description": "Switch Riot accounts and launch Riot games from Flow Launcher",
+  "Author": "Hyun",
+  "Version": "1.0.0",
+  "Language": "csharp",
+  "Website": "https://github.com/hyunwoo312/riot-launcher",
+  "UrlDownload": "https://github.com/hyunwoo312/riot-launcher/releases/download/v1.0.0/Flow.Launcher.Plugin.RiotLauncher.zip",
+  "UrlSourceCode": "https://github.com/hyunwoo312/riot-launcher/tree/main",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/hyunwoo312/riot-launcher@main/src/Flow.Launcher.Plugin.RiotLauncher/Images/riot.png"
+}


### PR DESCRIPTION
## Adds Riot Launcher, a native C# Riot Client plugin.

- Repo: https://github.com/hyunwoo312/riot-launcher
- v1.0.0 release: https://github.com/hyunwoo312/riot-launcher/releases/tag/v1.0.0
- Action keyword: `rt`

Features: launch Riot Client and installed Riot games from Flow Launcher, save Riot account credentials securely with Windows DPAPI, switch Riot accounts, set a default account for login fallback, update/remove/rename saved accounts, and display Riot ID metadata when available.

The plugin uses credential-based switching because Riot session files are inconsistent and can be invalidated by logout/client state, while encrypted saved credentials provide a more reliable and user-controlled switching flow.