### PR TITLE
Update QuickTodo to 1.5.0

### DIFF
--- a/plugins/QuickTodo-F8A3B1D4E6C2947F5A0B8D3E1C6F2A74.json
+++ b/plugins/QuickTodo-F8A3B1D4E6C2947F5A0B8D3E1C6F2A74.json
@@ -1,14 +1,14 @@
 {
     "ID": "F8A3B1D4E6C2947F5A0B8D3E1C6F2A74",
     "Name": "QuickTodo",
-    "Description": "Quick task management with priorities, categories, reminders, and Outlook Tasks support.",
+    "Description": "Quick task management with priorities, categories, reminders, Outlook Tasks support, and Outlook email search (os).",
     "Author": "TrueCrimeAudit",
-    "Version": "1.1.0",
+    "Version": "1.5.0",
     "Language": "csharp",
     "Website": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo",
-    "UrlDownload": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo/releases/download/v1.1.0/Flow.Launcher.Plugin.QuickTodo.zip",
+    "UrlDownload": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo/releases/download/v1.5.0/Flow.Launcher.Plugin.QuickTodo.zip",
     "UrlSourceCode": "https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo",
-    "IcoPath": "https://cdn.jsdelivr.net/gh/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo@master/Images/todo.png",
-    "LatestReleaseDate": "2026-05-27T22:42:24Z",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo@master/Images/td.png",
+    "LatestReleaseDate": "2026-06-29T12:08:20Z",
     "DateAdded": "2026-05-28T16:10:06Z"
 }


### PR DESCRIPTION
Updates the QuickTodo plugin entry to the new 1.5.0 release.

- **Version** 1.1.0 → 1.5.0, with the matching `v1.5.0` release download URL.
- **IcoPath** fix: the icon set was renamed (`todo.png` → `td.png`), so the old `@master/Images/todo.png` path now 404s. Points it at `@master/Images/td.png`, which matches the plugin's `plugin.json` IcoPath.
- **Description** updated to mention the new Outlook email search (`os`) keyword.

Release: https://github.com/TrueCrimeDev/Flow.Launcher.Plugin.QuickTodo/releases/tag/v1.5.0