### PR TITLE
Fix ci plugin changes detection

### DIFF
--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -48,10 +48,11 @@ jobs:
           ADDED=$(git diff --diff-filter=A --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'plugins/*.json' | head -c1)
           if [ -n "$ADDED" ]; then
             echo "plugin_additions=true" >> $GITHUB_OUTPUT
+            echo "New plugin manifest file/s added: true"
           else
             echo "plugin_additions=false" >> $GITHUB_OUTPUT
+            echo "New plugin manifest file/s added: false"
           fi
-          echo "New plugin file/s added: $ADDED"
 
   vt-plugin-scan:
     needs: vt-plugin-scan-changes-check

--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -44,6 +44,7 @@ jobs:
         id: detect_new
         if: github.event_name == 'pull_request_target' && steps.filter.outputs.plugins == 'true' && steps.filter.outputs.non_plugin_files == 'false'
         run: |
+          git fetch origin ${{ github.event.pull_request.base.sha }}
           ADDED=$(git diff --name-status ${{ github.event.pull_request.base.sha }}...HEAD -- 'plugins/*.json' | grep '^A' | head -c1)
           if [ -n "$ADDED" ]; then
             echo "plugin_additions=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -51,6 +51,7 @@ jobs:
           else
             echo "plugin_additions=false" >> $GITHUB_OUTPUT
           fi
+          echo "New plugin file/s added: $ADDED"
 
   vt-plugin-scan:
     needs: vt-plugin-scan-changes-check

--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       plugins: ${{ steps.filter.outputs.plugins }}
       non_plugin_files: ${{ steps.filter.outputs.non_plugin_files }}
+      plugin_additions: ${{ steps.detect_new.outputs.plugin_additions }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v6
@@ -39,11 +40,22 @@ jobs:
           echo "Plugin submission PRs must only create/modify plugin manifest files in the plugins directory."
           exit 1
 
+      - name: Detect new plugin file additions
+        id: detect_new
+        if: github.event_name == 'pull_request_target' && steps.filter.outputs.plugins == 'true' && steps.filter.outputs.non_plugin_files == 'false'
+        run: |
+          ADDED=$(git diff --name-status ${{ github.event.pull_request.base.sha }}...HEAD -- 'plugins/*.json' | grep '^A' | head -c1)
+          if [ -n "$ADDED" ]; then
+            echo "plugin_additions=true" >> $GITHUB_OUTPUT
+          else
+            echo "plugin_additions=false" >> $GITHUB_OUTPUT
+          fi
+
   vt-plugin-scan:
     needs: vt-plugin-scan-changes-check
     if: |
       always() && (
-        (github.event_name == 'pull_request_target' && needs.vt-plugin-scan-changes-check.outputs.plugins == 'true' && needs.vt-plugin-scan-changes-check.outputs.non_plugin_files == 'false') ||
+        (github.event_name == 'pull_request_target' && needs.vt-plugin-scan-changes-check.outputs.plugin_additions == 'true') ||
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'schedule'
       )

--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -45,7 +45,7 @@ jobs:
         if: github.event_name == 'pull_request_target' && steps.filter.outputs.plugins == 'true' && steps.filter.outputs.non_plugin_files == 'false'
         run: |
           git fetch origin ${{ github.event.pull_request.base.sha }}
-          ADDED=$(git diff --name-status ${{ github.event.pull_request.base.sha }}...HEAD -- 'plugins/*.json' | grep '^A' | head -c1)
+          ADDED=$(git diff --diff-filter=A --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'plugins/*.json' | head -c1)
           if [ -n "$ADDED" ]; then
             echo "plugin_additions=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Fix the changes detection to detect only when new files added not just changes made to the plugin directory files.

Tested:
1. When only plugin files modified -> VT changes detect pass -> VT scan skipped
2. When files changed but not in plugin directory -> VT changes detect pass -> VT scan skipped
3. When files changed and also plugin directory files changed -> VT changes detect fail
4. When only plugin directory files modified but no new files added -> VT changes detect pass -> VT scan is skipped
5. When only new Json file added in plugin directory -> VT changes detect pass -> VT scan runs