### PR TITLE
Add Live Tennis plugin

### DIFF
--- a/plugins/Live Tennis-122454f3-7f67-441c-b80b-624e45ee745c.json
+++ b/plugins/Live Tennis-122454f3-7f67-441c-b80b-624e45ee745c.json
@@ -1,0 +1,12 @@
+{
+  "ID": "122454f3-7f67-441c-b80b-624e45ee745c",
+  "Name": "Live Tennis",
+  "Description": "Live tennis scores at a keystroke: point-by-point live matches, set scores and serving indicator, plus player search (ranking, country) from Live Tennis API.",
+  "Author": "livetennisapi",
+  "Version": "1.0.0",
+  "Language": "python",
+  "Website": "https://livetennisapi.com",
+  "UrlDownload": "https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis/releases/download/v1.0.0/Flow.Launcher.Plugin.LiveTennis.zip",
+  "UrlSourceCode": "https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis/tree/main",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/livetennisapi/Flow.Launcher.Plugin.LiveTennis@main/Images/icon.png"
+}


### PR DESCRIPTION
Adds Live Tennis, a Python plugin that shows live tennis scores at a keystroke — point-by-point live matches with set scores and a serving indicator, plus player search (ranking, country) — backed by the Live Tennis API (users bring their own free key; no card required).

Repository:
https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis

Release:
https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis/releases/tag/v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)