### PR TITLE
Update VirusTotal whitelisting for Lively Wallpaper's TrellixENS detection

### DIFF
--- a/vt_whitelist.json
+++ b/vt_whitelist.json
@@ -20,6 +20,7 @@
     "sha256": "f46af3b0a6946be5108c0739b7bb474732509280b00ff6bb27c1ef706f6b6afd",
     "engine_threats": {
       "AhnLab-V3": "Trojan/Win.Malware-gen.C5018546",
+      "TrellixENS": "Artemis!6CD59C0F01A2",
       "Fortinet": "W32/PossibleThreat"
     },
     "reason": "Low detection (2)"


### PR DESCRIPTION
Update VirusTotal whitelisting for Lively Wallpaper Controller's new TrellixENS detection.
https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/runs/30478010373/job/90664493850
<img width="2268" height="830" alt="image" src="https://github.com/user-attachments/assets/32c9102f-cc78-402a-b1da-0f6f69bf309c" />
https://www.virustotal.com/gui/file/f46af3b0a6946be5108c0739b7bb474732509280b00ff6bb27c1ef706f6b6afd/detection

I have re-reviewed the repo code and confirmed download of plugin content.