### PR TITLE
Add Live Tennis plugin

### DIFF
--- a/plugins/Live Tennis-122454f3-7f67-441c-b80b-624e45ee745c.json
+++ b/plugins/Live Tennis-122454f3-7f67-441c-b80b-624e45ee745c.json
@@ -1,0 +1,12 @@
+{
+    "ID": "122454f3-7f67-441c-b80b-624e45ee745c",
+    "Name": "Live Tennis",
+    "Description": "Live tennis scores at a keystroke: point-by-point live matches, set scores and serving indicator, plus player search (ranking, country) from Live Tennis API.",
+    "Author": "livetennisapi",
+    "Version": "1.0.0",
+    "Language": "python",
+    "Website": "https://livetennisapi.com",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/livetennisapi/Flow.Launcher.Plugin.LiveTennis@main/Images/icon.png",
+    "UrlSourceCode": "https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis",
+    "UrlDownload": "https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis/releases/download/v1.0.0/Flow.Launcher.Plugin.LiveTennis.zip"
+}


### PR DESCRIPTION
Adds the **Live Tennis** plugin (`tennis` action keyword) — live tennis scores and player search powered by the [Live Tennis API](https://livetennisapi.com).

- **ID:** 122454f3-7f67-441c-b80b-624e45ee745c
- **Language:** python
- **Source:** https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis
- **Release zip:** https://github.com/livetennisapi/Flow.Launcher.Plugin.LiveTennis/releases/download/v1.0.0/Flow.Launcher.Plugin.LiveTennis.zip (built by the repo's automated "Publish Release" GitHub Actions workflow, dependencies vendored in `lib/`)
- **Icon:** served via jsDelivr CDN

The plugin queries the API over HTTPS with a user-supplied key (free tier available, no card); 401/429 responses are rendered as readable result rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)