### PR TITLE
Add reopened trigger to VirusTotal Scan workflow

### DIFF
--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: "0 17 * * *"
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read  # Restrict GITHUB_TOKEN


### PR DESCRIPTION
Retriggers this workflow when the PR is closed and then reopened.

This should give us a way to retrigger an up to date version of the workflow on existing PR's without adding new commits.

We could also do this with `ready_for_review` for draft and ready states.

Either way seems better than going manually committing to any currently PRs broken due to the workflow.