### PR TITLE
Add changed mode to download_plugins script

### DIFF
--- a/.github/workflows/security-vt-scan.yml
+++ b/.github/workflows/security-vt-scan.yml
@@ -80,9 +80,9 @@ jobs:
           key: plugin-zips-restore-not-used
           restore-keys: plugin-zips-
 
-      - name: Download plugin submitted in this PR
+      - name: Download plugins changed in this PR
         if: github.event_name == 'pull_request_target'
-        run: python ci/src/download_plugins.py --mode new --output-dir scan-files
+        run: python ci/src/download_plugins.py --mode changed --output-dir scan-files
 
       - name: Download all plugins with cache metadata
         if: github.event_name != 'pull_request_target'

--- a/ci/src/download_plugins.py
+++ b/ci/src/download_plugins.py
@@ -3,8 +3,9 @@
 This script reads plugin manifest JSON files from the ``plugins/``
 directory and downloads each plugin's ``UrlDownload`` ZIP into an output
 directory.  It supports a ``--mode new`` option to download only newly
-submitted plugins, and a local metadata cache to avoid re-downloading
-unchanged versions.
+submitted plugins, ``--mode changed`` to download plugins whose manifests
+were added or modified in a PR, and a local metadata cache to avoid
+re-downloading unchanged versions.
 
 Usage examples::
 
@@ -14,11 +15,15 @@ Usage examples::
     # Download only newly submitted plugins
     python ci/src/download_plugins.py --mode new
 
+    # Download plugins added or modified in a PR (base from GITHUB_BASE_REF)
+    python ci/src/download_plugins.py --mode changed
+
     # Use a cache metadata file to skip unchanged downloads
     python ci/src/download_plugins.py --cache-meta cache.json
 
 Environment variables:
     MODE                 Fallback for ``--mode``.
+    GITHUB_BASE_REF      PR base branch for ``--mode changed`` (auto-set by GitHub).
     OUTPUT_DIR           Fallback for ``--output-dir`` (default: plugin_downloads).
     DOWNLOAD_WORKERS     Max concurrent downloads (default: 8).
     DOWNLOAD_TIMEOUT_SEC HTTP request timeout in seconds (default: 120).
@@ -27,6 +32,7 @@ Environment variables:
 import argparse
 import json
 import os
+import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -81,6 +87,62 @@ def select_new_plugins() -> tuple[list[dict[str, str]], dict[str, Any]]:
         print("No new plugin submissions to download")
     else:
         print(f"Downloading {len(plugins)} new plugin submission(s)")
+    return plugins, meta
+
+
+def _get_changed_plugin_manifest_paths() -> list[str]:
+    """Return repo-relative paths of plugin manifests added or modified vs the PR base.
+
+    Fetches the base branch first, since a PR checkout is shallow and the
+    base commits are not present locally.  Uses a three-dot diff against
+    the merge-base so a changed ``UrlDownload`` on an existing plugin is
+    re-scanned, and main advancing does not over-include files.
+
+    Returns:
+        List of ``plugins/<Name>-<ID>.json`` paths.
+    """
+    # GITHUB_BASE_REF is set automatically for pull_request_target runs, otherwise fallback to main
+    base_ref = os.getenv("GITHUB_BASE_REF") or "main"
+
+    # PR checkout is shallow so the base branch must be fetched again
+    subprocess.run(["git", "fetch", "origin", base_ref], check=True, capture_output=True, text=True)
+
+    # Three-dot diff shows only this PR's changes vs the merge-base.
+    # Only added or modified manifests matter. Deleted files are not considered.
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=AM",  # added or modified only
+            "--name-only",  # paths only, no content
+            f"origin/{base_ref}...HEAD",  # three-dot: this PR's changes
+            "--",  # end of options, the rest are paths
+            "plugins/*.json",  # only plugin manifest files
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def select_changed_plugins() -> tuple[list[dict[str, str]], dict[str, Any]]:
+    """Select plugins whose manifest files were added or modified vs the PR base.
+
+    Treats an updated manifest like a new submission, so a change to an
+    existing plugin's ``UrlDownload`` is downloaded and scanned.
+
+    Returns:
+        Tuple of ``(changed_plugins, metadata_dict)``.
+    """
+    changed_paths = _get_changed_plugin_manifest_paths()
+    by_filename = {manifest_filename(plugin): plugin for plugin in plugin_reader()}
+    plugins = [by_filename[Path(path).name] for path in changed_paths if Path(path).name in by_filename]
+    meta: dict[str, Any] = {"mode": "changed", "changed_plugins": len(plugins)}
+    if not plugins:
+        print("No changed plugin manifests to download")
+    else:
+        print(f"Downloading {len(plugins)} changed plugin manifest(s)")
     return plugins, meta
 
 
@@ -250,7 +312,7 @@ def main() -> None:
     parser.add_argument(
         "--mode",
         default=None,
-        choices=["new"],
+        choices=["new", "changed"],
         help="Selection mode (default: download all plugins, falls back to MODE env var)",
     )
     parser.add_argument(
@@ -275,6 +337,8 @@ def main() -> None:
 
     if mode == "new":
         plugins, meta = select_new_plugins()
+    elif mode == "changed":
+        plugins, meta = select_changed_plugins()
     else:
         plugins = plugin_reader()
         print(f"Downloading all {len(plugins)} plugins")

--- a/ci/src/download_plugins.py
+++ b/ci/src/download_plugins.py
@@ -135,9 +135,8 @@ def select_changed_plugins() -> tuple[list[dict[str, str]], dict[str, Any]]:
     Returns:
         Tuple of ``(changed_plugins, metadata_dict)``.
     """
-    changed_paths = _get_changed_plugin_manifest_paths()
-    by_filename = {manifest_filename(plugin): plugin for plugin in plugin_reader()}
-    plugins = [by_filename[Path(path).name] for path in changed_paths if Path(path).name in by_filename]
+    changed_names = {Path(path).name for path in _get_changed_plugin_manifest_paths()}
+    plugins = [plugin for plugin in plugin_reader() if manifest_filename(plugin) in changed_names]
     meta: dict[str, Any] = {"mode": "changed", "changed_plugins": len(plugins)}
     if not plugins:
         print("No changed plugin manifests to download")

--- a/tests/test_download_plugins.py
+++ b/tests/test_download_plugins.py
@@ -87,6 +87,127 @@ def test_select_new_plugins_skips_ids_not_in_reader():
         assert plugins[0]["ID"] == "1"
 
 
+def test_get_changed_plugin_manifest_paths_fetches_base_then_diffs():
+    # A PR checkout is shallow, so we fetch the base branch before diffing against it. 
+    # Only added or modified plugin manifests should come back.
+    
+    base_ref = "main"
+    diff_output = "plugins/Foo-1.json\nplugins/Bar-2.json\n"
+
+    # simulate
+    fetch_result = MagicMock()
+    diff_result = MagicMock(stdout=diff_output)
+    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+        paths = dp._get_changed_plugin_manifest_paths()
+
+    # check
+    assert paths == ["plugins/Foo-1.json", "plugins/Bar-2.json"]
+    assert mock_run.call_args_list[0][0][0] == ["git", "fetch", "origin", base_ref]
+    command = mock_run.call_args_list[1][0][0]
+    assert command[0:4] == ["git", "diff", "--diff-filter=AM", "--name-only"]
+    assert f"origin/{base_ref}...HEAD" in command
+    assert "plugins/*.json" in command
+
+
+def test_get_changed_plugin_manifest_paths_uses_base_ref_env(monkeypatch):
+    # The base branch comes from GITHUB_BASE_REF, 
+    # so a PR that targets something other than main still diffs against the right branch.
+    
+    base_ref = "test"
+
+    # simulate
+    monkeypatch.setenv("GITHUB_BASE_REF", base_ref)
+    fetch_result = MagicMock()
+    diff_result = MagicMock(stdout="")
+    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+        dp._get_changed_plugin_manifest_paths()
+
+    # check
+    assert mock_run.call_args_list[0][0][0] == ["git", "fetch", "origin", base_ref]
+    assert f"origin/{base_ref}...HEAD" in mock_run.call_args_list[1][0][0]
+
+
+def test_get_changed_plugin_manifest_paths_skips_blank_lines():
+    # git output can include blank lines, and those must not be treated as manifest paths.
+    
+    diff_output = "plugins/Foo-1.json\n\n"
+
+    # simulate
+    fetch_result = MagicMock()
+    diff_result = MagicMock(stdout=diff_output)
+    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+        paths = dp._get_changed_plugin_manifest_paths()
+
+    # check
+    assert paths == ["plugins/Foo-1.json"]
+
+
+def test_select_changed_plugins_returns_matching_manifests():
+    # Changed paths only count when they map to a real manifest in the plugins folder. 
+    # This is what lets a modified UrlDownload on an existing plugin get re-scanned.
+    
+    changed_paths = ["plugins/Foo-1.json", "plugins/Baz-3.json"]
+    all_plugins = [
+        {"ID": "1", "Name": "Foo"},
+        {"ID": "2", "Name": "Bar"},
+        {"ID": "3", "Name": "Baz"},
+    ]
+
+    # simulate
+    with (
+        patch.object(dp, "_get_changed_plugin_manifest_paths", return_value=changed_paths),
+        patch.object(dp, "plugin_reader", return_value=all_plugins),
+    ):
+        plugins, meta = dp.select_changed_plugins()
+
+    # check
+    assert [p["ID"] for p in plugins] == ["1", "3"]
+    assert meta["mode"] == "changed"
+    assert meta["changed_plugins"] == 2
+
+
+def test_select_changed_plugins_returns_empty_when_no_matches():
+    # A path that does not match any manifest, 
+    # for example a stray json file in the plugins folder, 
+    # should be ignored rather than crash selection.
+    
+    changed_paths = ["plugins/Missing-9.json"]
+    all_plugins = [{"ID": "1", "Name": "Foo"}]
+
+    # simulate
+    with (
+        patch.object(dp, "_get_changed_plugin_manifest_paths", return_value=changed_paths),
+        patch.object(dp, "plugin_reader", return_value=all_plugins),
+    ):
+        plugins, meta = dp.select_changed_plugins()
+
+    # check
+    assert plugins == []
+    assert meta["changed_plugins"] == 0
+
+
+def test_main_mode_changed(monkeypatch):
+    # The changed mode should route through select_changed_plugins
+    # and then hand the result to download_all.
+
+    # simulate
+    monkeypatch.setenv("MODE", "changed")
+    monkeypatch.setattr(sys, "argv", ["download_plugins.py"])
+    with (
+        patch.object(dp, "download_all") as mock_download_all,
+        patch.object(dp, "select_changed_plugins") as mock_select,
+    ):
+        mock_select.return_value = (
+            [_make_plugin("changed1")],
+            {"mode": "changed", "changed_plugins": 1},
+        )
+        dp.main()
+
+    # check
+    mock_select.assert_called_once_with()
+    mock_download_all.assert_called_once_with([_make_plugin("changed1")], Path("plugin_downloads"), cache_meta_path=None)
+
+
 def test_download_plugin_successfully(tmp_path, monkeypatch):
     monkeypatch.setenv("DOWNLOAD_TIMEOUT_SEC", "30")
     mock_response = MagicMock(spec=requests.Response)


### PR DESCRIPTION
Added new mode to download_plugins script - "changed"
It uses git diff to include both modified and added plugins

Made security-vt-scan.yml‎ use this mode instead of "new"

resolves #726