### PR TITLE
Whitelist Uninstaller+ and Win Hotkey plugins

### DIFF
--- a/vt_whitelist.json
+++ b/vt_whitelist.json
@@ -76,5 +76,21 @@
       "DeepInstinct": "MALICIOUS"
     },
     "reason": "Likely the low-level Win32 desktop overlay behavior, resembling shellcode or unpacker behavior to heuristics"
+  },
+  {
+    "manifest_file": "Uninstaller+-dd2fd217-e332-4fbd-9012-4940e08d41a7.json",
+    "sha256": "a029c8c64e0e60bcd8316e0167e4eb4d2e5d346dbad4e84a8926942a678dff69",
+    "engine_threats": {
+      "MaxSecure": "Trojan.Malware.300983.susgen"
+    },
+    "reason": "Likely from making system changes which can look Trojan-like to heuristic AV engines"
+  },
+  {
+    "manifest_file": "Win Hotkey-7D530704C68E4838896BBA5C4C1DE7DF.json",
+    "sha256": "c38802b878661f39aa64b4002d8a81d30c784cb832d9f918ee2d388602ba584a",
+    "engine_threats": {
+      "TrellixENS": "Artemis!1E654A6EC9EE"
+    },
+    "reason": "Likely flagged for dynamic AutoHotkey execution and keyboard-hook/input-simulation behavior"
   }
 ]


### PR DESCRIPTION
Whitelist Uninstaller+ and Win Hotkey plugins due to VT false positive alerts. Both repos re-reviewed.