### PR TITLE
Add MonitorCowboy plugin

### DIFF
--- a/plugins/MonitorCowboy-baf19c15c7054fcfb2ad422fb9dc161d.json
+++ b/plugins/MonitorCowboy-baf19c15c7054fcfb2ad422fb9dc161d.json
@@ -1,0 +1,12 @@
+{
+  "ID": "baf19c15c7054fcfb2ad422fb9dc161d",
+  "Name": "MonitorCowboy",
+  "Description": "Control your monitors over DDC/CI - switch input source and set volume from Flow.",
+  "Author": "True347",
+  "Version": "1.1.1",
+  "Language": "csharp",
+  "Website": "https://github.com/True347/MonitorCowboy",
+  "UrlDownload": "https://github.com/True347/MonitorCowboy/releases/download/v1.1.1/Flow.Launcher.Plugin.MonitorCowboy.zip",
+  "UrlSourceCode": "https://github.com/True347/MonitorCowboy/tree/main",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/True347/MonitorCowboy@main/Images/app.png"
+}


### PR DESCRIPTION
Adds **MonitorCowboy**, a C# plugin to switch a monitor's input source and set its speaker volume over DDC/CI, all under one action keyword (`mc`) with a rofi-style drill-down menu.

- **ID:** `baf19c15c7054fcfb2ad422fb9dc161d`
- **Repo:** https://github.com/True347/MonitorCowboy
- **Release:** [v1.1.1](https://github.com/True347/MonitorCowboy/releases/tag/v1.1.1) (zip has `plugin.json` at root, no Flow SDK assemblies bundled)

Checklist:
- [x] `plugins/MonitorCowboy-<id>.json` added; copied fields match the plugin's `plugin.json`
- [x] `UrlDownload`, `UrlSourceCode`, `IcoPath` all resolve (release zip + jsdelivr icon verified live)
- [x] GitHub Actions build/release workflow set up (auto-publishes on version bump)
- [x] Conforms with the Plugin Store policy — no malicious code, no piracy, no deceptive use, no inappropriate content

DDC/CI is slow enough that the query path never talks to a monitor: results render from a warm cache while reads and writes run on a background worker per monitor, and all bus traffic passes through one process-wide lock, since concurrent DDC/CI is unsafe even across different displays. Every write is confirmed by reading the value back, so a change is never reported as applied on the strength of a return code alone.

Targets .NET 9 on Windows. The only runtime package reference is the Flow SDK itself; the sole native dependency is the Windows Monitor Configuration API (`dxva2.dll`).
