### PR TITLE
Add 简繁转换 plugin

### DIFF
--- a/plugins/简繁转换-621d4d5c-cf05-4031-a427-11688b0767b3.json
+++ b/plugins/简繁转换-621d4d5c-cf05-4031-a427-11688b0767b3.json
@@ -1,0 +1,13 @@
+{
+    "ID": "621d4d5c-cf05-4031-a427-11688b0767b3",
+    "Name": "简繁转换",
+    "Description": "快速在简体中文、通用繁体、台湾繁体和香港繁体之间转换",
+    "Author": "lennonlu",
+    "Version": "0.1.0",
+    "Language": "csharp",
+    "Website": "https://github.com/lennonlu/Flow.Launcher.Plugin.ChineseConverter",
+    "UrlDownload": "https://github.com/lennonlu/Flow.Launcher.Plugin.ChineseConverter/releases/download/v0.1.0/Flow.Launcher.Plugin.ChineseConverter.zip",
+    "UrlSourceCode": "https://github.com/lennonlu/Flow.Launcher.Plugin.ChineseConverter/tree/main",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/lennonlu/Flow.Launcher.Plugin.ChineseConverter@main/src/Flow.Launcher.Plugin.ChineseConverter/Images/app.svg",
+    "MinimumAppVersion": "2.1.1"
+}


### PR DESCRIPTION
## What changed

Adds 简繁转换 to the Flow Launcher plugin manifest.

## Plugin

- Action keyword: `st`
- Converts Simplified Chinese to general, Taiwan, and Hong Kong Traditional Chinese
- Converts Traditional Chinese back to Simplified Chinese
- Copies the selected result to the clipboard

## Release

- Source: https://github.com/lennonlu/Flow.Launcher.Plugin.ChineseConverter
- Release: https://github.com/lennonlu/Flow.Launcher.Plugin.ChineseConverter/releases/tag/v0.1.0
- Automated CI and tag-based GitHub Release workflow are configured

## Validation

- Plugin loads successfully in Flow Launcher 2.1.1
- 8 automated conversion tests pass
- Release ZIP contains `plugin.json`, plugin DLL, dictionaries, icon, and license files
- Release ZIP excludes `Flow.Launcher.Plugin.dll`
- 1,800-character conversion benchmark P95: 8.7 ms