### PR TITLE
Fix changed mode shallow clone git diff 128 error

### DIFF
--- a/ci/src/download_plugins.py
+++ b/ci/src/download_plugins.py
@@ -104,11 +104,6 @@ def _repo_is_shallow() -> bool:
 def _get_changed_plugin_manifest_paths() -> list[str]:
     """Return repo-relative paths of plugin manifests added or modified vs the PR base.
 
-    Fetches the base branch first, since a PR checkout is shallow and the
-    base commits are not present locally.  Uses a three-dot diff against
-    the merge-base so a changed ``UrlDownload`` on an existing plugin is
-    re-scanned, and main advancing does not over-include files.
-
     Returns:
         List of ``plugins/<Name>-<ID>.json`` paths.
     """
@@ -135,7 +130,7 @@ def _get_changed_plugin_manifest_paths() -> list[str]:
             "plugins/*.json",  # only plugin manifest files
         ],
         check=True,
-        capture_output=True,
+        stdout=subprocess.PIPE,
         text=True,
     )
     return [line for line in result.stdout.splitlines() if line]

--- a/ci/src/download_plugins.py
+++ b/ci/src/download_plugins.py
@@ -90,6 +90,17 @@ def select_new_plugins() -> tuple[list[dict[str, str]], dict[str, Any]]:
     return plugins, meta
 
 
+def _repo_is_shallow() -> bool:
+    """Return True when the checkout is a shallow clone."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip() == "true"
+
+
 def _get_changed_plugin_manifest_paths() -> list[str]:
     """Return repo-relative paths of plugin manifests added or modified vs the PR base.
 
@@ -104,8 +115,12 @@ def _get_changed_plugin_manifest_paths() -> list[str]:
     # GITHUB_BASE_REF is set automatically for pull_request_target runs, otherwise fallback to main
     base_ref = os.getenv("GITHUB_BASE_REF") or "main"
 
-    # PR checkout is shallow so the base branch must be fetched again
-    subprocess.run(["git", "fetch", "origin", base_ref], check=True, capture_output=True, text=True)
+    # A three-dot diff needs the merge-base, which a shallow checkout cannot provide
+    if _repo_is_shallow():
+        subprocess.run(["git", "fetch", "--unshallow", "origin"], check=True)
+
+    # Keep the base branch ref current before diffing against it
+    subprocess.run(["git", "fetch", "origin", base_ref], check=True)
 
     # Three-dot diff shows only this PR's changes vs the merge-base.
     # Only added or modified manifests matter. Deleted files are not considered.

--- a/tests/test_download_plugins.py
+++ b/tests/test_download_plugins.py
@@ -87,58 +87,79 @@ def test_select_new_plugins_skips_ids_not_in_reader():
         assert plugins[0]["ID"] == "1"
 
 
-def test_get_changed_plugin_manifest_paths_fetches_base_then_diffs():
-    # A PR checkout is shallow, so we fetch the base branch before diffing against it. 
-    # Only added or modified plugin manifests should come back.
-    
+def test_get_changed_plugin_manifest_paths_fetches_base_before_diffing():
     base_ref = "main"
     diff_output = "plugins/Foo-1.json\nplugins/Bar-2.json\n"
 
-    # simulate
     fetch_result = MagicMock()
     diff_result = MagicMock(stdout=diff_output)
-    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+    with (
+        patch.object(dp, "_repo_is_shallow", return_value=False),
+        patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run,
+    ):
         paths = dp._get_changed_plugin_manifest_paths()
 
-    # check
     assert paths == ["plugins/Foo-1.json", "plugins/Bar-2.json"]
-    assert mock_run.call_args_list[0][0][0] == ["git", "fetch", "origin", base_ref]
-    command = mock_run.call_args_list[1][0][0]
-    assert command[0:4] == ["git", "diff", "--diff-filter=AM", "--name-only"]
-    assert f"origin/{base_ref}...HEAD" in command
-    assert "plugins/*.json" in command
+    fetch_command, diff_command = [call.args[0] for call in mock_run.call_args_list]
+    assert fetch_command == ["git", "fetch", "origin", base_ref]
+    assert diff_command[0:4] == ["git", "diff", "--diff-filter=AM", "--name-only"]
+    assert f"origin/{base_ref}...HEAD" in diff_command
+    assert "plugins/*.json" in diff_command
+
+
+def test_get_changed_plugin_manifest_paths_unshallows_before_fetching_base():
+    base_ref = "main"
+    diff_output = "plugins/Foo-1.json\n"
+
+    with (
+        patch.object(dp, "_repo_is_shallow", return_value=True),
+        patch.object(
+            dp.subprocess,
+            "run",
+            side_effect=[MagicMock(), MagicMock(), MagicMock(stdout=diff_output)],
+        ) as mock_run,
+    ):
+        paths = dp._get_changed_plugin_manifest_paths()
+
+    assert paths == ["plugins/Foo-1.json"]
+    unshallow_command, fetch_command, diff_command = [
+        call.args[0] for call in mock_run.call_args_list
+    ]
+    assert unshallow_command == ["git", "fetch", "--unshallow", "origin"]
+    assert fetch_command == ["git", "fetch", "origin", base_ref]
+    assert diff_command[0:4] == ["git", "diff", "--diff-filter=AM", "--name-only"]
+    assert f"origin/{base_ref}...HEAD" in diff_command
+    assert "plugins/*.json" in diff_command
 
 
 def test_get_changed_plugin_manifest_paths_uses_base_ref_env(monkeypatch):
-    # The base branch comes from GITHUB_BASE_REF, 
-    # so a PR that targets something other than main still diffs against the right branch.
-    
     base_ref = "test"
 
-    # simulate
     monkeypatch.setenv("GITHUB_BASE_REF", base_ref)
     fetch_result = MagicMock()
     diff_result = MagicMock(stdout="")
-    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+    with (
+        patch.object(dp, "_repo_is_shallow", return_value=False),
+        patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run,
+    ):
         dp._get_changed_plugin_manifest_paths()
 
-    # check
-    assert mock_run.call_args_list[0][0][0] == ["git", "fetch", "origin", base_ref]
-    assert f"origin/{base_ref}...HEAD" in mock_run.call_args_list[1][0][0]
+    fetch_command, diff_command = [call.args[0] for call in mock_run.call_args_list]
+    assert fetch_command == ["git", "fetch", "origin", base_ref]
+    assert f"origin/{base_ref}...HEAD" in diff_command
 
 
 def test_get_changed_plugin_manifest_paths_skips_blank_lines():
-    # git output can include blank lines, and those must not be treated as manifest paths.
-    
     diff_output = "plugins/Foo-1.json\n\n"
 
-    # simulate
     fetch_result = MagicMock()
     diff_result = MagicMock(stdout=diff_output)
-    with patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run:
+    with (
+        patch.object(dp, "_repo_is_shallow", return_value=False),
+        patch.object(dp.subprocess, "run", side_effect=[fetch_result, diff_result]) as mock_run,
+    ):
         paths = dp._get_changed_plugin_manifest_paths()
 
-    # check
     assert paths == ["plugins/Foo-1.json"]
 
 


### PR DESCRIPTION
follow up of #728
Currently the virus check is broken again

See https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/actions/runs/32579242764/job/97046041761?pr=725

This pr fixes the issue in changed mode where a shallow clone caused the git diff to fail
Now it unshallows the repo if that occurs

Also improved tests, some docstring, and made git diff errors show in logs