### PR TITLE
Update Playnite icon path

### DIFF
--- a/plugins/Playnite-625A2812D5364D708582FDD9ACCD8C93.json
+++ b/plugins/Playnite-625A2812D5364D708582FDD9ACCD8C93.json
@@ -8,7 +8,7 @@
     "Website": "https://github.com/Garulf/Playnite-Plugin",
     "UrlDownload": "https://github.com/Garulf/Playnite-Plugin/releases/download/v3.0.0/Playnite-Plugin-3.0.0.zip",
     "UrlSourceCode": "https://github.com/Garulf/playnite-plugin/tree/main",
-    "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/playnite-plugin@main/icon.png",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/Garulf/playnite-plugin@main/data/icon.png",
     "Tested": true,
     "LatestReleaseDate": "2026-08-25T15:39:10Z",
     "DateAdded": "2022-10-08T16:26:57Z"


### PR DESCRIPTION
The Playnite icon moved to `data/icon.png` when I rewrote the plugin for v3.0.0, so the current `IcoPath` points at a file that is no longer in the repo root. raw.githubusercontent already 404s on it and jsdelivr is still serving a cached copy, so the store icon will break once that cache expires.

This just points it at the new path. Everything else in the entry is the same.
