### PR TITLE
Add FlowYoutubeRedirect plugin

### DIFF
--- a/plugins/FlowYoutubeRedirect-1B14AD49687C4429A2D422296759D7F4.json
+++ b/plugins/FlowYoutubeRedirect-1B14AD49687C4429A2D422296759D7F4.json
@@ -1,0 +1,12 @@
+{
+  "ID": "1B14AD49687C4429A2D422296759D7F4",
+  "Name": "FlowYoutubeRedirect",
+  "Description": "Search YouTube in Flow Launcher or open searches directly on YouTube",
+  "Author": "Viraj Kapur",
+  "Version": "2.3.1",
+  "Language": "python",
+  "Website": "https://github.com/Mavon2309/FlowYoutubeRedirect",
+  "UrlDownload": "https://github.com/Mavon2309/FlowYoutubeRedirect/releases/download/v2.3.1/FlowYoutubeRedirect.zip",
+  "UrlSourceCode": "https://github.com/Mavon2309/FlowYoutubeRedirect/tree/main",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/Mavon2309/FlowYoutubeRedirect@main/icon.png"
+}


### PR DESCRIPTION
## Plugin submission

Adds **FlowYoutubeRedirect 2.3.1**, a Flow Launcher plugin that searches YouTube inside Flow or opens the same search on YouTube.

- Public source repository and versioned release ZIP
- Automated GitHub Actions build and release workflow
- MIT licensed with upstream FlowYouTube attribution
- Unique Flow Launcher plugin ID
