### PR TITLE
Add Anytype

### DIFF
--- a/plugins/Anytype-2354084a-18cb-4c06-9d92-2507a3fb2bba.json
+++ b/plugins/Anytype-2354084a-18cb-4c06-9d92-2507a3fb2bba.json
@@ -1,0 +1,12 @@
+{
+    "ID": "2354084a-18cb-4c06-9d92-2507a3fb2bba",
+    "Name": "Anytype",
+    "Description": "Search your Anytype vault and open objects, including full text inside pages",
+    "Author": "Willson Gan",
+    "Version": "1.0.1",
+    "Language": "python",
+    "Website": "https://github.com/willsongan/Flow.Launcher.Plugin.Anytype",
+    "UrlDownload": "https://github.com/willsongan/Flow.Launcher.Plugin.Anytype/releases/download/v1.0.1/Flow.Launcher.Plugin.Anytype.zip",
+    "UrlSourceCode": "https://github.com/willsongan/Flow.Launcher.Plugin.Anytype",
+    "IcoPath": "https://cdn.jsdelivr.net/gh/willsongan/Flow.Launcher.Plugin.Anytype@main/Images/app.png"
+}


### PR DESCRIPTION
Add Anytype

Adds [Anytype](https://github.com/willsongan/Flow.Launcher.Plugin.Anytype) — search an Anytype vault and open objects, including full text inside pages.

**Action keyword:** `at` · **Language:** python · **Version:** 1.0.1

### What it does

- `at <text>` searches object names, previews, and text inside page bodies
- `at status` reports vault location and whether content search is working
- Enter opens the object in Anytype; Shift+Enter copies a deep link, shareable link, or object ID

### Notes for review

The release zip contains a compiled `tantivy` binary in `lib/`, so flagging it here up front:

- It is the published PyPI wheel (`tantivy==0.26.0`), installed by the release workflow on a Windows runner rather than committed by hand. The workflow fails the build if the bundled artifact is not a Windows `.pyd`.
- Anytype's HTTP API only matches object names and the short preview snippet, so text deeper inside a page is unreachable through it. The plugin reads Anytype's own Tantivy index **read-only** to find that text and merges the matches. Anytype keeps the writer lock; the plugin never takes it and never modifies the vault.
- Nothing is copied to disk. Only an API key, the detected index path, and space names are persisted.
- The only outbound network request the plugin can make is an optional `tantivy` download from PyPI, and only when the user explicitly triggers it. Everything else is `127.0.0.1`.
- Without `tantivy` the plugin degrades to name and preview search rather than failing.

Windows-only, as is Flow Launcher. Tests run on every push and pull request; releases are built and published from GitHub Actions.
