### PR TITLE
Add GitHub CLI plugin

### DIFF
--- a/plugins/GitHub CLI-47615338-321a-419e-b3c4-38ea9f11c614.json
+++ b/plugins/GitHub CLI-47615338-321a-419e-b3c4-38ea9f11c614.json
@@ -3,10 +3,10 @@
   "Name": "GitHub CLI",
   "Description": "Search your repositories, organizations, pull requests, and recent popular repositories using the local gh CLI",
   "Author": "Liaco123",
-  "Version": "0.1.0",
+  "Version": "0.1.1",
   "Language": "csharp",
   "Website": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli",
-  "UrlDownload": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli/releases/download/v0.1.0/Flow.Launcher.Plugin.GitHubCli.zip",
+  "UrlDownload": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli/releases/download/v0.1.1/Flow.Launcher.Plugin.GitHubCli.zip",
   "UrlSourceCode": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli",
   "IcoPath": "https://cdn.jsdelivr.net/gh/Liaco123/Flow.Launcher.Plugin.GitHubCli@main/src/Flow.Launcher.Plugin.GitHubCli/Images/app.png",
   "MinimumAppVersion": "2.1.3"

--- a/plugins/GitHub CLI-47615338-321a-419e-b3c4-38ea9f11c614.json
+++ b/plugins/GitHub CLI-47615338-321a-419e-b3c4-38ea9f11c614.json
@@ -1,0 +1,13 @@
+{
+  "ID": "47615338-321a-419e-b3c4-38ea9f11c614",
+  "Name": "GitHub CLI",
+  "Description": "Search your repositories, organizations, pull requests, and recent popular repositories using the local gh CLI",
+  "Author": "Liaco123",
+  "Version": "0.1.0",
+  "Language": "csharp",
+  "Website": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli",
+  "UrlDownload": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli/releases/download/v0.1.0/Flow.Launcher.Plugin.GitHubCli.zip",
+  "UrlSourceCode": "https://github.com/Liaco123/Flow.Launcher.Plugin.GitHubCli",
+  "IcoPath": "https://cdn.jsdelivr.net/gh/Liaco123/Flow.Launcher.Plugin.GitHubCli@main/src/Flow.Launcher.Plugin.GitHubCli/Images/app.png",
+  "MinimumAppVersion": "2.1.3"
+}


### PR DESCRIPTION
Adds the new GitHub CLI Flow Launcher plugin.

Features:
- Uses the locally authenticated gh CLI and stores no token
- Lists repositories owned by the current account
- Lists the current account organizations and opens each organization page
- Searches pull requests and shows authored/review-requested work
- Shows repositories created in the last 1, 7, or 30 days sorted by current stars

Release and validation:
- v0.1.0 is a public, non-prerelease GitHub Release with the expected ZIP asset
- Plugin CI passes 58 tests on Windows
- Manifest validator passes all 11 tests
- Repository, release ZIP, and jsDelivr icon URLs return HTTP 200